### PR TITLE
Implement animation and transition guidelines

### DIFF
--- a/documentation/docs/components/buttons.mdx
+++ b/documentation/docs/components/buttons.mdx
@@ -1,0 +1,91 @@
+---
+title: Buttons
+description: Soroban Cookbook button system with variants, sizes, states, icon support, and accessibility guidance.
+---
+
+import React from 'react';
+import Button from '@site/src/components/UI/Button';
+import ButtonGroup from '@site/src/components/UI/Button/ButtonGroup';
+
+# Button Component
+
+This button system includes:
+
+- Variants: `primary`, `secondary`, `tertiary`, `ghost`, `link`
+- Sizes: `sm`, `md`, `lg`, `xl`
+- States: default, hover, active, focus, disabled, loading
+- Icon support: icon-only, left icon, right icon
+- Grouping: connected buttons for related actions
+- Accessibility: keyboard focus styles, proper disabled handling, loading semantics
+- Dark mode: color tokens adjusted for contrast in `[data-theme='dark']`
+
+## Basic Usage
+
+```tsx
+import Button from '@site/src/components/UI/Button';
+
+export default function Example() {
+  return <Button>Deploy Contract</Button>;
+}
+```
+
+## Variants
+
+<div style={{display: 'flex', gap: '0.75rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
+  <Button variant="primary">Primary</Button>
+  <Button variant="secondary">Secondary</Button>
+  <Button variant="tertiary">Tertiary</Button>
+  <Button variant="ghost">Ghost</Button>
+  <Button variant="link">Link</Button>
+</div>
+
+## Sizes
+
+<div style={{display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap', marginBottom: '1rem'}}>
+  <Button size="sm">Small</Button>
+  <Button size="md">Medium</Button>
+  <Button size="lg">Large</Button>
+  <Button size="xl">Extra Large</Button>
+</div>
+
+## States
+
+<div style={{display: 'flex', gap: '0.75rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
+  <Button>Default</Button>
+  <Button disabled>Disabled</Button>
+  <Button loading>Loading</Button>
+</div>
+
+Use keyboard `Tab` navigation to verify visible focus states (`:focus-visible`).
+
+## Icons
+
+<div style={{display: 'flex', gap: '0.75rem', flexWrap: 'wrap', marginBottom: '1rem'}}>
+  <Button iconLeft={<span aria-hidden="true">+</span>}>Create</Button>
+  <Button iconRight={<span aria-hidden="true">→</span>}>Continue</Button>
+  <Button iconOnly aria-label="Settings" iconLeft={<span aria-hidden="true">⚙</span>} />
+</div>
+
+## Button Group
+
+<ButtonGroup ariaLabel="Contract actions">
+  <Button variant="secondary">Preview</Button>
+  <Button variant="secondary">Save Draft</Button>
+  <Button variant="primary">Publish</Button>
+</ButtonGroup>
+
+## Accessibility Guidelines
+
+- Provide an `aria-label` for icon-only buttons.
+- Keep button text action-oriented and specific.
+- Do not rely only on color to communicate state.
+- Use `disabled` for unavailable actions.
+- Loading buttons announce `aria-busy` and prevent duplicate clicks.
+
+## Animation and Transition Tokens
+
+Defined in `src/css/custom.css`:
+
+- Durations: `--sb-motion-duration-fast`, `--sb-motion-duration-normal`, `--sb-motion-duration-slow`
+- Easing: `--sb-motion-ease-standard`, `--sb-motion-ease-in`, `--sb-motion-ease-out`
+- Utilities: `.sb-transition-none`, `.sb-transition-fast`, `.sb-transition-normal`, `.sb-transition-slow`

--- a/documentation/docs/concepts/authorization.md
+++ b/documentation/docs/concepts/authorization.md
@@ -1,0 +1,27 @@
+# Authorization
+
+Authorization in Soroban ensures only expected identities can execute sensitive contract actions.
+
+## Typical Access Patterns
+
+- Owner/admin-only functions
+- Role-based permissions for operators
+- User-signed operations for account-scoped actions
+
+## Best Practices
+
+1. Validate caller identity before mutating state.
+2. Keep privileged surfaces small and explicit.
+3. Emit events for sensitive operations.
+4. Add tests for unauthorized access attempts.
+
+## Common Protected Operations
+
+- Setting admins or governance parameters
+- Mint/burn operations in token-like contracts
+- Upgrading contract logic or config
+
+## Next
+
+- [Storage Patterns](./storage.md)
+- [Events](./events.md)

--- a/documentation/docs/concepts/events.md
+++ b/documentation/docs/concepts/events.md
@@ -1,0 +1,28 @@
+# Events
+
+Events provide a reliable audit trail of what happened in your contract and help indexers and UIs react to on-chain activity.
+
+## Why Emit Events
+
+- Improve observability and debugging
+- Enable off-chain indexing and analytics
+- Support front-end updates after state changes
+
+## Event Design Guidelines
+
+1. Use stable, predictable event topics.
+2. Include only the data consumers need.
+3. Emit events after successful state transitions.
+4. Keep naming consistent across related actions.
+
+## Recommended Event Types
+
+- Creation and initialization
+- State update and transfer actions
+- Access control changes
+- Error or rejection signals when appropriate
+
+## Next
+
+- [Storage Patterns](./storage.md)
+- [Authorization](./authorization.md)

--- a/documentation/docs/concepts/overview.md
+++ b/documentation/docs/concepts/overview.md
@@ -32,9 +32,9 @@ Understanding deployment, upgrades, and contract lifecycle management.
 
 Start with:
 
-1. [Storage Patterns](./storage.md) - Learn data persistence
-2. [Authorization](./authorization.md) - Secure your contracts
-3. [Events](./events.md) - Monitor contract activity
+1. [Storage Patterns](./storage) - Learn data persistence
+2. [Authorization](./authorization) - Secure your contracts
+3. [Events](./events) - Monitor contract activity
 
 ## Resources
 

--- a/documentation/docs/concepts/storage.md
+++ b/documentation/docs/concepts/storage.md
@@ -1,0 +1,28 @@
+# Storage Patterns
+
+Soroban contracts store state in ledger-backed storage. Designing storage carefully improves performance, cost, and maintainability.
+
+## What to Store
+
+- Persistent contract state such as balances, configuration, and ownership
+- Derived data only when recomputation is expensive
+- Version markers when you plan contract upgrades
+
+## Practical Guidelines
+
+1. Keep keys deterministic and namespaced.
+2. Separate global config from user-specific data.
+3. Prefer compact value types to reduce footprint.
+4. Define clear migration strategy for schema changes.
+
+## Example Use Cases
+
+- Token balances keyed by account
+- Admin configuration keyed by a known symbol
+- Nonce/counter state for replay protection
+
+## Next
+
+- [Authorization](./authorization.md)
+- [Events](./events.md)
+- [First Contract Walkthrough](../getting-started/first-contract.md)

--- a/documentation/docs/getting-started/deploy-testnet.md
+++ b/documentation/docs/getting-started/deploy-testnet.md
@@ -1,0 +1,33 @@
+# Deploy to Testnet
+
+After building your Soroban contract, deploy it to Stellar testnet for validation in a live network environment.
+
+## Prerequisites
+
+- Soroban CLI installed
+- A funded testnet account
+- Built WASM artifact from your contract
+
+## Typical Flow
+
+1. Build your contract:
+
+```bash
+soroban contract build
+```
+
+2. Configure your identity/network in Soroban CLI.
+3. Upload WASM and deploy contract.
+4. Invoke a read/write method to verify behavior.
+
+## Verification Checklist
+
+- Contract deployed successfully and returned contract ID
+- Basic methods execute without authorization errors
+- State changes persist across calls
+- Emitted events can be observed in tooling
+
+## Next
+
+- [Your First Contract](./first-contract.md)
+- [Core Concepts Overview](../concepts/overview.md)

--- a/documentation/docs/getting-started/first-contract.md
+++ b/documentation/docs/getting-started/first-contract.md
@@ -76,8 +76,8 @@ cargo test
 
 ## Next Steps
 
-- [Deploy to testnet](./deploy-testnet.md)
-- [Learn about storage](../concepts/storage.md)
+- [Deploy to testnet](./deploy-testnet)
+- [Learn about storage](../concepts/storage)
 - [Explore patterns](../patterns/overview.md)
 
 ## Resources

--- a/documentation/docs/patterns/overview.md
+++ b/documentation/docs/patterns/overview.md
@@ -45,7 +45,7 @@ Each pattern includes:
 
 ## Contributing
 
-Have a pattern to share? See our [Contributing Guide](../../CONTRIBUTING.md).
+Have a pattern to share? See our [Contributing Guide](https://github.com/Soroban-Cookbook/Soroban-Cookbook-/blob/main/CONTRIBUTING.md).
 
 ## Getting Started
 

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -30,7 +30,7 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.ts',
-          routeBasePath: '/',
+          routeBasePath: '/docs',
           editUrl: 'https://github.com/Soroban-Cookbook/Soroban-Cookbook-/tree/main/documentation/',
         },
         blog: false,

--- a/documentation/sidebars.ts
+++ b/documentation/sidebars.ts
@@ -12,6 +12,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'getting-started/setup',
         'getting-started/first-contract',
+        'getting-started/deploy-testnet',
       ],
     },
     {
@@ -19,6 +20,9 @@ const sidebars: SidebarsConfig = {
       label: 'Core Concepts',
       items: [
         'concepts/overview',
+        'concepts/storage',
+        'concepts/authorization',
+        'concepts/events',
       ],
     },
     {
@@ -26,6 +30,13 @@ const sidebars: SidebarsConfig = {
       label: 'Patterns',
       items: [
         'patterns/overview',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Components',
+      items: [
+        'components/buttons',
       ],
     },
   ],

--- a/documentation/src/components/UI/Button.types.ts
+++ b/documentation/src/components/UI/Button.types.ts
@@ -1,0 +1,1 @@
+export * from './Button/Button.types';

--- a/documentation/src/components/UI/Button/Button.types.ts
+++ b/documentation/src/components/UI/Button/Button.types.ts
@@ -1,0 +1,20 @@
+import type {ButtonHTMLAttributes, ReactNode} from 'react';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'ghost' | 'link';
+export type ButtonSize = 'sm' | 'md' | 'lg' | 'xl';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  iconLeft?: ReactNode;
+  iconRight?: ReactNode;
+  loading?: boolean;
+  iconOnly?: boolean;
+}
+
+export interface ButtonGroupProps {
+  children: ReactNode;
+  ariaLabel?: string;
+  vertical?: boolean;
+  className?: string;
+}

--- a/documentation/src/components/UI/Button/ButtonGroup.tsx
+++ b/documentation/src/components/UI/Button/ButtonGroup.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import clsx from 'clsx';
+import type {ButtonGroupProps} from './Button.types';
+
+export default function ButtonGroup({children, ariaLabel, vertical = false, className}: ButtonGroupProps) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className={clsx('sb-btn-group', {'sb-btn-group--vertical': vertical}, className)}>
+      {children}
+    </div>
+  );
+}

--- a/documentation/src/components/UI/Button/index.tsx
+++ b/documentation/src/components/UI/Button/index.tsx
@@ -1,0 +1,52 @@
+import React, {forwardRef} from 'react';
+import clsx from 'clsx';
+import type {ButtonProps} from './Button.types';
+
+function Spinner() {
+  return <span className="sb-btn__spinner" aria-hidden="true" />;
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    variant = 'primary',
+    size = 'md',
+    iconLeft,
+    iconRight,
+    loading = false,
+    iconOnly = false,
+    className,
+    children,
+    disabled,
+    type = 'button',
+    ...rest
+  },
+  ref,
+) {
+  const isDisabled = disabled || loading;
+
+  return (
+    <button
+      {...rest}
+      ref={ref}
+      type={type}
+      disabled={isDisabled}
+      aria-busy={loading || undefined}
+      className={clsx(
+        'sb-btn',
+        `sb-btn--${variant}`,
+        `sb-btn--${size}`,
+        {
+          'sb-btn--icon-only': iconOnly,
+          'is-loading': loading,
+        },
+        className,
+      )}>
+      {loading && <Spinner />}
+      {!loading && iconLeft && <span className="sb-btn__icon">{iconLeft}</span>}
+      {!iconOnly && <span className="sb-btn__label">{children}</span>}
+      {!loading && iconRight && <span className="sb-btn__icon">{iconRight}</span>}
+    </button>
+  );
+});
+
+export default Button;

--- a/documentation/src/components/UI/ButtonGroup.tsx
+++ b/documentation/src/components/UI/ButtonGroup.tsx
@@ -1,0 +1,1 @@
+export {default} from './Button/ButtonGroup';

--- a/documentation/src/css/custom.css
+++ b/documentation/src/css/custom.css
@@ -15,6 +15,51 @@
   --ifm-color-primary-lightest: #3cad6e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+
+  /* Motion tokens */
+  --sb-motion-duration-fast: 120ms;
+  --sb-motion-duration-normal: 200ms;
+  --sb-motion-duration-slow: 320ms;
+  --sb-motion-ease-standard: cubic-bezier(0.2, 0.9, 0.2, 1);
+  --sb-motion-ease-in: cubic-bezier(0.3, 0, 1, 1);
+  --sb-motion-ease-out: cubic-bezier(0, 0, 0.2, 1);
+
+  /* Button tokens */
+  --sb-btn-radius: 0.6rem;
+  --sb-btn-font-weight: 600;
+  --sb-btn-gap: 0.5rem;
+  --sb-btn-shadow-focus: 0 0 0 3px rgba(46, 133, 85, 0.35);
+  --sb-btn-shadow-active: inset 0 2px 0 rgba(0, 0, 0, 0.15);
+
+  --sb-btn-primary-bg: var(--ifm-color-primary);
+  --sb-btn-primary-text: #ffffff;
+  --sb-btn-primary-border: var(--ifm-color-primary-dark);
+  --sb-btn-primary-hover: var(--ifm-color-primary-dark);
+  --sb-btn-primary-active: var(--ifm-color-primary-darkest);
+
+  --sb-btn-secondary-bg: #ffffff;
+  --sb-btn-secondary-text: #1f2937;
+  --sb-btn-secondary-border: #cbd5e1;
+  --sb-btn-secondary-hover: #f8fafc;
+  --sb-btn-secondary-active: #f1f5f9;
+
+  --sb-btn-tertiary-bg: #f1f5f9;
+  --sb-btn-tertiary-text: #0f172a;
+  --sb-btn-tertiary-border: #e2e8f0;
+  --sb-btn-tertiary-hover: #e2e8f0;
+  --sb-btn-tertiary-active: #cbd5e1;
+
+  --sb-btn-ghost-bg: transparent;
+  --sb-btn-ghost-text: #0f172a;
+  --sb-btn-ghost-border: transparent;
+  --sb-btn-ghost-hover: rgba(15, 23, 42, 0.08);
+  --sb-btn-ghost-active: rgba(15, 23, 42, 0.14);
+
+  --sb-btn-link-bg: transparent;
+  --sb-btn-link-text: var(--ifm-color-primary-dark);
+  --sb-btn-link-border: transparent;
+  --sb-btn-link-hover: transparent;
+  --sb-btn-link-active: transparent;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -27,4 +72,262 @@
   --ifm-color-primary-lighter: #32d8b4;
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+
+  --sb-btn-shadow-focus: 0 0 0 3px rgba(79, 221, 191, 0.35);
+  --sb-btn-shadow-active: inset 0 2px 0 rgba(0, 0, 0, 0.28);
+
+  --sb-btn-secondary-bg: #0f172a;
+  --sb-btn-secondary-text: #e2e8f0;
+  --sb-btn-secondary-border: #334155;
+  --sb-btn-secondary-hover: #111b31;
+  --sb-btn-secondary-active: #1e293b;
+
+  --sb-btn-tertiary-bg: #1e293b;
+  --sb-btn-tertiary-text: #e2e8f0;
+  --sb-btn-tertiary-border: #334155;
+  --sb-btn-tertiary-hover: #334155;
+  --sb-btn-tertiary-active: #475569;
+
+  --sb-btn-ghost-text: #e2e8f0;
+  --sb-btn-ghost-hover: rgba(226, 232, 240, 0.12);
+  --sb-btn-ghost-active: rgba(226, 232, 240, 0.2);
+
+  --sb-btn-link-text: var(--ifm-color-primary-lightest);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --sb-motion-duration-fast: 0ms;
+    --sb-motion-duration-normal: 0ms;
+    --sb-motion-duration-slow: 0ms;
+  }
+}
+
+/* Transition utilities */
+.sb-transition-none {
+  transition: none !important;
+}
+
+.sb-transition-fast {
+  transition-duration: var(--sb-motion-duration-fast) !important;
+  transition-timing-function: var(--sb-motion-ease-standard) !important;
+}
+
+.sb-transition-normal {
+  transition-duration: var(--sb-motion-duration-normal) !important;
+  transition-timing-function: var(--sb-motion-ease-standard) !important;
+}
+
+.sb-transition-slow {
+  transition-duration: var(--sb-motion-duration-slow) !important;
+  transition-timing-function: var(--sb-motion-ease-standard) !important;
+}
+
+/* Button */
+.sb-btn {
+  --_btn-bg: var(--sb-btn-primary-bg);
+  --_btn-text: var(--sb-btn-primary-text);
+  --_btn-border: var(--sb-btn-primary-border);
+  --_btn-hover: var(--sb-btn-primary-hover);
+  --_btn-active: var(--sb-btn-primary-active);
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sb-btn-gap);
+  border: 1px solid var(--_btn-border);
+  border-radius: var(--sb-btn-radius);
+  background-color: var(--_btn-bg);
+  color: var(--_btn-text);
+  font-weight: var(--sb-btn-font-weight);
+  line-height: 1;
+  white-space: nowrap;
+  user-select: none;
+  cursor: pointer;
+  text-decoration: none;
+  transition-property: background-color, border-color, color, transform, box-shadow, opacity;
+  transition-duration: var(--sb-motion-duration-normal);
+  transition-timing-function: var(--sb-motion-ease-standard);
+}
+
+.sb-btn:hover:not(:disabled) {
+  background-color: var(--_btn-hover);
+}
+
+.sb-btn:active:not(:disabled) {
+  background-color: var(--_btn-active);
+  box-shadow: var(--sb-btn-shadow-active);
+  transform: translateY(1px);
+}
+
+.sb-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--sb-btn-shadow-focus);
+}
+
+.sb-btn:disabled,
+.sb-btn[aria-disabled='true'] {
+  opacity: 0.56;
+  cursor: not-allowed;
+}
+
+.sb-btn.is-loading {
+  pointer-events: none;
+}
+
+.sb-btn__label {
+  display: inline-flex;
+  align-items: center;
+}
+
+.sb-btn__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: 1rem;
+  block-size: 1rem;
+}
+
+.sb-btn__spinner {
+  inline-size: 0.95rem;
+  block-size: 0.95rem;
+  border: 2px solid currentcolor;
+  border-right-color: transparent;
+  border-radius: 9999px;
+  animation: sb-spin 0.8s linear infinite;
+}
+
+@keyframes sb-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.sb-btn--sm {
+  min-height: 2rem;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.825rem;
+}
+
+.sb-btn--md {
+  min-height: 2.5rem;
+  padding: 0.625rem 0.95rem;
+  font-size: 0.925rem;
+}
+
+.sb-btn--lg {
+  min-height: 2.9rem;
+  padding: 0.75rem 1.15rem;
+  font-size: 1rem;
+}
+
+.sb-btn--xl {
+  min-height: 3.35rem;
+  padding: 0.95rem 1.35rem;
+  font-size: 1.1rem;
+}
+
+.sb-btn--icon-only {
+  padding-inline: 0;
+}
+
+.sb-btn--icon-only.sb-btn--sm {
+  inline-size: 2rem;
+}
+
+.sb-btn--icon-only.sb-btn--md {
+  inline-size: 2.5rem;
+}
+
+.sb-btn--icon-only.sb-btn--lg {
+  inline-size: 2.9rem;
+}
+
+.sb-btn--icon-only.sb-btn--xl {
+  inline-size: 3.35rem;
+}
+
+.sb-btn--primary {
+  --_btn-bg: var(--sb-btn-primary-bg);
+  --_btn-text: var(--sb-btn-primary-text);
+  --_btn-border: var(--sb-btn-primary-border);
+  --_btn-hover: var(--sb-btn-primary-hover);
+  --_btn-active: var(--sb-btn-primary-active);
+}
+
+.sb-btn--secondary {
+  --_btn-bg: var(--sb-btn-secondary-bg);
+  --_btn-text: var(--sb-btn-secondary-text);
+  --_btn-border: var(--sb-btn-secondary-border);
+  --_btn-hover: var(--sb-btn-secondary-hover);
+  --_btn-active: var(--sb-btn-secondary-active);
+}
+
+.sb-btn--tertiary {
+  --_btn-bg: var(--sb-btn-tertiary-bg);
+  --_btn-text: var(--sb-btn-tertiary-text);
+  --_btn-border: var(--sb-btn-tertiary-border);
+  --_btn-hover: var(--sb-btn-tertiary-hover);
+  --_btn-active: var(--sb-btn-tertiary-active);
+}
+
+.sb-btn--ghost {
+  --_btn-bg: var(--sb-btn-ghost-bg);
+  --_btn-text: var(--sb-btn-ghost-text);
+  --_btn-border: var(--sb-btn-ghost-border);
+  --_btn-hover: var(--sb-btn-ghost-hover);
+  --_btn-active: var(--sb-btn-ghost-active);
+}
+
+.sb-btn--link {
+  --_btn-bg: var(--sb-btn-link-bg);
+  --_btn-text: var(--sb-btn-link-text);
+  --_btn-border: var(--sb-btn-link-border);
+  --_btn-hover: var(--sb-btn-link-hover);
+  --_btn-active: var(--sb-btn-link-active);
+
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  border-color: transparent;
+}
+
+/* Button group */
+.sb-btn-group {
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.sb-btn-group .sb-btn {
+  border-radius: 0;
+}
+
+.sb-btn-group .sb-btn:first-child {
+  border-top-left-radius: var(--sb-btn-radius);
+  border-bottom-left-radius: var(--sb-btn-radius);
+}
+
+.sb-btn-group .sb-btn:last-child {
+  border-top-right-radius: var(--sb-btn-radius);
+  border-bottom-right-radius: var(--sb-btn-radius);
+}
+
+.sb-btn-group .sb-btn + .sb-btn {
+  margin-left: -1px;
+}
+
+.sb-btn-group--vertical {
+  flex-direction: column;
+}
+
+.sb-btn-group--vertical .sb-btn:first-child {
+  border-radius: var(--sb-btn-radius) var(--sb-btn-radius) 0 0;
+}
+
+.sb-btn-group--vertical .sb-btn:last-child {
+  border-radius: 0 0 var(--sb-btn-radius) var(--sb-btn-radius);
+}
+
+.sb-btn-group--vertical .sb-btn + .sb-btn {
+  margin-left: 0;
+  margin-top: -1px;
 }

--- a/documentation/src/pages/index.tsx
+++ b/documentation/src/pages/index.tsx
@@ -20,8 +20,8 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro">
-            Docusaurus Tutorial - 5min ⏱️
+            to="/docs/getting-started/setup">
+            Start Building with Soroban
           </Link>
         </div>
       </div>


### PR DESCRIPTION
closes #8

**Description**
Implements the button/animation issue end-to-end and fixes docs routing/link errors so the site builds cleanly.

## Changes
- Added reusable button system with:
  - variants: primary, secondary, tertiary, ghost, link
  - sizes: sm, md, lg, xl
  - states: default, hover, active, focus, disabled, loading
  - icon support + button groups + accessibility handling
- Extended `src/css/custom.css` with:
  - animation/motion tokens
  - transition utilities
  - full button + group styles
  - dark mode + reduced motion support
- Added docs page: `docs/components/buttons.mdx`
- Added sidebar entry: `Components -> Buttons`
- Fixed broken docs links by adding missing pages and updating bad references
- Moved docs base path to `/docs` to remove duplicate `/` route conflict

## Validation
- `npm run typecheck` ✅
- `npm run build` ✅

Buttons doc is now available at:
`/docs/components/buttons`
