### PR TITLE
feat: Implement Reusable Badge & Tag System

### DIFF
--- a/documentation/docs/design-system/badges-tags.mdx
+++ b/documentation/docs/design-system/badges-tags.mdx
@@ -4,9 +4,13 @@ description: Difficulty badges, category tags, status indicators, size variants,
 sidebar_label: Badges & Tags
 ---
 
+import { Badge, Tag } from '@site/src/components/Badge';
+
 # Badges & Tags
 
 Badges are small status indicators. Tags are categorical labels. Both are compact, color-coded, and accessible.
+
+The `Badge` and `Tag` React components are the canonical way to render these in docs and components. They map directly to the global `.sb-badge` / `.sb-tag` CSS classes in `badges-tags.css`.
 
 ---
 
@@ -14,13 +18,29 @@ Badges are small status indicators. Tags are categorical labels. Both are compac
 
 Visual skill-level indicators for recipes and tutorials.
 
-| Badge | Color | Token | Use |
-|-------|-------|-------|-----|
-| **Beginner** | Green | `--sb-color-success` / `#22c55e` | First contract, basic storage, hello-world |
-| **Intermediate** | Amber | `--sb-color-warning` / `#f59e0b` | Cross-contract calls, custom types, auth |
-| **Advanced** | Red | `--sb-color-error` / `#ef4444` | Upgradeable contracts, flash loans, oracles |
+<div className="sb-badge-group" style={{marginBottom: '1rem'}}>
+  <Badge variant="beginner">Beginner</Badge>
+  <Badge variant="intermediate">Intermediate</Badge>
+  <Badge variant="advanced">Advanced</Badge>
+</div>
 
-### Markup
+| Variant | Color | Use |
+|---------|-------|-----|
+| `beginner` | Green | First contract, basic storage, hello-world |
+| `intermediate` | Amber | Cross-contract calls, custom types, auth |
+| `advanced` | Red | Upgradeable contracts, flash loans, oracles |
+
+### React usage
+
+```tsx
+import { Badge } from '@site/src/components/Badge';
+
+<Badge variant="beginner" />
+<Badge variant="intermediate" />
+<Badge variant="advanced" />
+```
+
+### HTML class usage
 
 ```html
 <span class="sb-badge sb-badge--beginner">Beginner</span>
@@ -28,11 +48,39 @@ Visual skill-level indicators for recipes and tutorials.
 <span class="sb-badge sb-badge--advanced">Advanced</span>
 ```
 
-### When to use
+---
 
-- Place next to the recipe title or in the card header.
-- One difficulty badge per recipe — pick the highest skill required.
-- Don't stack multiple difficulty badges on the same item.
+## Status Badges
+
+Indicators for content freshness and availability.
+
+<div className="sb-badge-group" style={{marginBottom: '1rem'}}>
+  <Badge variant="new">New</Badge>
+  <Badge variant="updated">Updated</Badge>
+  <Badge variant="stable">Stable</Badge>
+  <Badge variant="experimental">Experimental</Badge>
+  <Badge variant="draft">Draft</Badge>
+  <Badge variant="coming-soon">Coming Soon</Badge>
+  <Badge variant="deprecated">Deprecated</Badge>
+</div>
+
+| Variant | Style | Use |
+|---------|-------|-----|
+| `new` | Solid green | Content added in the last 30 days |
+| `updated` | Solid blue | Recently revised content |
+| `stable` | Solid teal | Production-ready, well-tested |
+| `experimental` | Purple tint | Unstable API, subject to change |
+| `draft` | Gray tint | Work in progress |
+| `coming-soon` | Outlined neutral | Placeholder for unreleased content |
+| `deprecated` | Solid red | Should no longer be used |
+
+### React usage
+
+```tsx
+<Badge variant="new" />
+<Badge variant="stable" />
+<Badge variant="deprecated" />
+```
 
 ---
 
@@ -40,258 +88,138 @@ Visual skill-level indicators for recipes and tutorials.
 
 Flexible labels for pattern and topic categorization.
 
-| Tag | Background | Text |
-|-----|------------|------|
-| **Token** | `--sb-color-primary-100` | `--sb-color-primary-700` |
-| **DeFi** | `--sb-color-secondary-100` | `--sb-color-secondary-700` |
-| **NFT** | `--sb-color-info-subtle` | `--sb-color-info-dark` |
-| **Security** | `--sb-color-error-subtle` | `--sb-color-error-dark` |
-| **Storage** | `--sb-color-warning-subtle` | `--sb-color-warning-dark` |
-| **Auth** | `--sb-color-neutral-100` | `--sb-color-neutral-700` |
+<div className="sb-tag-group" style={{marginBottom: '1rem'}}>
+  <Tag variant="token">Token</Tag>
+  <Tag variant="defi">DeFi</Tag>
+  <Tag variant="nft">NFT</Tag>
+  <Tag variant="security">Security</Tag>
+  <Tag variant="storage">Storage</Tag>
+  <Tag variant="auth">Auth</Tag>
+  <Tag variant="governance">Governance</Tag>
+  <Tag variant="error-handling">Error Handling</Tag>
+</div>
 
-### Markup
+### React usage
+
+```tsx
+import { Tag } from '@site/src/components/Badge';
+
+<Tag variant="storage" />
+<Tag variant="defi" />
+<Tag variant="token" />
+```
+
+### HTML class usage
 
 ```html
 <span class="sb-tag sb-tag--token">Token</span>
 <span class="sb-tag sb-tag--defi">DeFi</span>
-<span class="sb-tag sb-tag--nft">NFT</span>
-<span class="sb-tag sb-tag--security">Security</span>
 <span class="sb-tag sb-tag--storage">Storage</span>
-<span class="sb-tag sb-tag--auth">Auth</span>
 ```
-
-### Adding new categories
-
-Follow the pattern: pick a semantic or palette color, use the `*-subtle` shade for background and the `*-dark` shade for text. This ensures WCAG AA contrast in both light and dark modes.
-
----
-
-## Status Badges
-
-Indicators for content freshness and availability.
-
-| Status | Style | Use |
-|--------|-------|-----|
-| **New** | Solid green bg, white text | Content added in the last 30 days |
-| **Updated** | Solid blue bg, white text | Recently revised content |
-| **Coming Soon** | Outlined neutral, muted text | Placeholder for unreleased content |
-| **Deprecated** | Solid red bg, white text | Content that should no longer be used |
-
-### Markup
-
-```html
-<span class="sb-badge sb-badge--new">New</span>
-<span class="sb-badge sb-badge--updated">Updated</span>
-<span class="sb-badge sb-badge--coming-soon">Coming Soon</span>
-<span class="sb-badge sb-badge--deprecated">Deprecated</span>
-```
-
-### Token mapping
-
-| Status | Light bg | Light text | Dark bg | Dark text |
-|--------|----------|------------|---------|-----------|
-| New | `--sb-color-success` | `#fff` | `--sb-color-success` | `#fff` |
-| Updated | `--sb-color-info` | `#fff` | `--sb-color-info` | `#fff` |
-| Coming Soon | `transparent` | `--sb-color-neutral-500` | `transparent` | `--sb-color-neutral-500` |
-| Deprecated | `--sb-color-error` | `#fff` | `--sb-color-error` | `#fff` |
 
 ---
 
 ## Size Variants
 
-Three sizes for different contexts.
+Three sizes for different contexts. Size modifiers work on both badges and tags.
+
+<div style={{display: 'flex', flexDirection: 'column', gap: '0.75rem', marginBottom: '1rem'}}>
+  <div className="sb-badge-group">
+    <Badge variant="beginner" size="sm">Beginner sm</Badge>
+    <Badge variant="intermediate" size="sm">Intermediate sm</Badge>
+    <Badge variant="advanced" size="sm">Advanced sm</Badge>
+  </div>
+  <div className="sb-badge-group">
+    <Badge variant="beginner" size="md">Beginner md</Badge>
+    <Badge variant="intermediate" size="md">Intermediate md</Badge>
+    <Badge variant="advanced" size="md">Advanced md</Badge>
+  </div>
+  <div className="sb-badge-group">
+    <Badge variant="beginner" size="lg">Beginner lg</Badge>
+    <Badge variant="intermediate" size="lg">Intermediate lg</Badge>
+    <Badge variant="advanced" size="lg">Advanced lg</Badge>
+  </div>
+</div>
 
 | Size | Class | Height | Padding | Font | Use case |
 |------|-------|--------|---------|------|----------|
-| **small** | `sb-badge--sm` | 20px | 2px 6px | 11px | Inline with text, table cells |
-| **medium** | `sb-badge--md` | 24px | 3px 8px | 12px | Card headers, list items (default) |
-| **large** | `sb-badge--lg` | 28px | 4px 12px | 13px | Page headers, hero sections |
+| `sm` | `sb-badge--sm` | 20px | 2px 6px | 11px | Inline with text, table cells |
+| `md` | `sb-badge--md` | 24px | 3px 8px | 12px | Card headers, list items (default) |
+| `lg` | `sb-badge--lg` | 28px | 4px 12px | 13px | Page headers, hero sections |
 
-```html
-<span class="sb-badge sb-badge--new sb-badge--sm">New</span>
-<span class="sb-badge sb-badge--new sb-badge--md">New</span>
-<span class="sb-badge sb-badge--new sb-badge--lg">New</span>
+```tsx
+<Badge variant="new" size="sm" />
+<Badge variant="new" size="md" />   {/* default */}
+<Badge variant="new" size="lg" />
+
+<Tag variant="storage" size="sm" />
+<Tag variant="storage" size="lg" />
 ```
 
-Same sizes apply to tags — use `sb-tag--sm`, `sb-tag--md`, `sb-tag--lg`.
+---
+
+## Interactive (Clickable) Badges & Tags
+
+Add `clickable` to get hover/focus/active states. Use `as="button"` or `as="a"` on `Tag` for proper semantics.
+
+<div className="sb-tag-group" style={{marginBottom: '1rem'}}>
+  <Tag variant="defi" clickable as="button">DeFi ↗</Tag>
+  <Tag variant="token" clickable as="button">Token ↗</Tag>
+  <Tag variant="storage" clickable as="button">Storage ↗</Tag>
+</div>
+
+```tsx
+// Filter chip
+<Tag variant="defi" clickable as="button" onClick={handleFilter}>DeFi</Tag>
+
+// Navigation link
+<Tag variant="token" clickable as="a" href="/docs/patterns?tag=token">Token</Tag>
+```
 
 ---
 
 ## CSS Custom Properties
 
-All badge/tag tokens to add to your design tokens CSS file.
+All tokens live in `design-tokens.css`. Key variables:
 
 ```css
-:root {
-  /* Badge base */
-  --sb-badge-radius: 9999px;
-  --sb-badge-font-weight: 600;
-  --sb-badge-letter-spacing: 0.01em;
+/* Sizes */
+--sb-badge-height-sm: 1.25rem;
+--sb-badge-height-md: 1.5rem;
+--sb-badge-height-lg: 1.75rem;
 
-  /* Badge sizes */
-  --sb-badge-height-sm: 20px;
-  --sb-badge-height-md: 24px;
-  --sb-badge-height-lg: 28px;
-  --sb-badge-px-sm: 6px;
-  --sb-badge-px-md: 8px;
-  --sb-badge-px-lg: 12px;
-  --sb-badge-font-sm: 11px;
-  --sb-badge-font-md: 12px;
-  --sb-badge-font-lg: 13px;
+/* Difficulty (light — auto-inverted in dark mode) */
+--sb-badge-beginner-bg:         rgba(34, 197, 94, 0.15);
+--sb-badge-beginner-text:       #15803d;
+--sb-badge-beginner-border:     rgba(34, 197, 94, 0.35);
 
-  /* Difficulty badges */
-  --sb-badge-beginner-bg: var(--sb-color-success-subtle);
-  --sb-badge-beginner-text: var(--sb-color-success-dark);
-  --sb-badge-beginner-border: var(--sb-color-success);
-  --sb-badge-intermediate-bg: var(--sb-color-warning-subtle);
-  --sb-badge-intermediate-text: var(--sb-color-warning-dark);
-  --sb-badge-intermediate-border: var(--sb-color-warning);
-  --sb-badge-advanced-bg: var(--sb-color-error-subtle);
-  --sb-badge-advanced-text: var(--sb-color-error-dark);
-  --sb-badge-advanced-border: var(--sb-color-error);
+/* Status */
+--sb-badge-new-bg:              #16a34a;
+--sb-badge-new-text:            #ffffff;
 
-  /* Status badges */
-  --sb-badge-new-bg: var(--sb-color-success);
-  --sb-badge-new-text: #ffffff;
-  --sb-badge-updated-bg: var(--sb-color-info);
-  --sb-badge-updated-text: #ffffff;
-  --sb-badge-coming-soon-bg: transparent;
-  --sb-badge-coming-soon-text: var(--sb-color-neutral-500);
-  --sb-badge-coming-soon-border: var(--sb-color-neutral-300);
-  --sb-badge-deprecated-bg: var(--sb-color-error);
-  --sb-badge-deprecated-text: #ffffff;
-
-  /* Tag base */
-  --sb-tag-radius: 6px;
-  --sb-tag-font-weight: 500;
-}
-```
-
----
-
-## Base CSS Classes
-
-```css
-/* Badge — pill shape, solid or outlined */
-.sb-badge {
-  display: inline-flex;
-  align-items: center;
-  height: var(--sb-badge-height-md);
-  padding-inline: var(--sb-badge-px-md);
-  font-size: var(--sb-badge-font-md);
-  font-weight: var(--sb-badge-font-weight);
-  letter-spacing: var(--sb-badge-letter-spacing);
-  line-height: 1;
-  border-radius: var(--sb-badge-radius);
-  border: 1px solid transparent;
-  white-space: nowrap;
-  user-select: none;
-  transition: background-color 0.15s ease, transform 0.15s ease;
-}
-
-/* Tag — rounded rectangle, softer look */
-.sb-tag {
-  display: inline-flex;
-  align-items: center;
-  height: var(--sb-badge-height-md);
-  padding-inline: var(--sb-badge-px-md);
-  font-size: var(--sb-badge-font-md);
-  font-weight: var(--sb-tag-font-weight);
-  line-height: 1;
-  border-radius: var(--sb-tag-radius);
-  white-space: nowrap;
-  user-select: none;
-  transition: background-color 0.15s ease, transform 0.15s ease;
-}
-```
-
----
-
-## Interactive States
-
-For clickable badges and tags (e.g. filter chips), add the `sb-badge--clickable` or `sb-tag--clickable` modifier.
-
-```css
-.sb-badge--clickable,
-.sb-tag--clickable {
-  cursor: pointer;
-}
-
-.sb-badge--clickable:hover,
-.sb-tag--clickable:hover {
-  transform: translateY(-1px);
-  filter: brightness(0.95);
-}
-
-.sb-badge--clickable:active,
-.sb-tag--clickable:active {
-  transform: translateY(0);
-  filter: brightness(0.9);
-}
-
-.sb-badge--clickable:focus-visible,
-.sb-tag--clickable:focus-visible {
-  outline: 2px solid var(--ifm-color-primary);
-  outline-offset: 2px;
-}
-```
-
-Use `<button>` or `<a>` instead of `<span>` when the badge/tag is clickable:
-
-```html
-<!-- Filtering by tag -->
-<button class="sb-tag sb-tag--defi sb-tag--clickable">DeFi</button>
-
-<!-- Linking to filtered view -->
-<a href="/docs/patterns?tag=token" class="sb-tag sb-tag--token sb-tag--clickable">Token</a>
+/* Tags */
+--sb-tag-storage-bg:            rgba(245, 158, 11, 0.12);
+--sb-tag-storage-text:          #b45309;
 ```
 
 ---
 
 ## Accessibility
 
-### Contrast
-
-- Solid badges (New, Updated, Deprecated): white text on colored bg — passes AA at all sizes.
+- Solid badges (New, Updated, Deprecated, Stable): white text on colored bg — passes WCAG AA at all sizes.
 - Subtle badges (Beginner, Intermediate, Advanced): dark text on tinted bg — minimum 4.5:1 ratio.
 - Coming Soon: muted text on transparent — border provides visual boundary.
 
-### Screen readers
-
-Badges are decorative when paired with visible text. Use `aria-hidden="true"` in those cases:
+When the badge is decorative (paired with visible heading text), add `aria-hidden="true"`:
 
 ```html
-<!-- Badge next to visible heading — redundant for SR -->
 <h3>Deploy to Testnet <span class="sb-badge sb-badge--beginner" aria-hidden="true">Beginner</span></h3>
 ```
 
-When the badge is the **only** indicator, keep it accessible:
+When the badge is the only difficulty signal, use `asStatus` (React) or `role="status"` (HTML):
 
-```html
-<!-- Badge is the only difficulty signal in a card -->
-<span class="sb-badge sb-badge--advanced" role="status">Advanced</span>
+```tsx
+<Badge variant="advanced" asStatus />
 ```
 
-### Clickable badges
-
-- Use `<button>` for actions (filter, toggle).
-- Use `<a>` for navigation.
-- Never put `onclick` on a `<span>` — it's not keyboard accessible.
-
----
-
-## Usage Guidelines
-
-### Do
-
-- Use one difficulty badge per recipe
-- Place status badges near the title — top-right of cards or inline after headings
-- Use subtle/tinted backgrounds for category tags so they don't compete with CTAs
-- Group related tags together with `gap: 6px` (`--sb-space-1` + `--sb-space-half`)
-
-### Don't
-
-- Stack more than 4 tags on a single card — it becomes visual noise
-- Use badge colors that don't match the semantic meaning (e.g. green for "Deprecated")
-- Make every badge clickable — only add interaction when filtering/navigation exists
-- Mix badge sizes within the same row
+For clickable badges/tags, always use `<button>` or `<a>` — never `<span>` with `onClick`.

--- a/documentation/docs/patterns/overview.md
+++ b/documentation/docs/patterns/overview.md
@@ -18,13 +18,13 @@ Browse battle-tested contract patterns for various use cases.
 
 ### [Hello World Storage](/docs/patterns/hello-world)
 
-**Difficulty**: Beginner | **Category**: Storage | **Status**: Stable
+<span class="sb-badge sb-badge--beginner">Beginner</span> <span class="sb-tag sb-tag--storage">Storage</span> <span class="sb-badge sb-badge--stable">Stable</span>
 
 Minimal Soroban contract demonstrating instance storage. Perfect starting point for understanding contract structure and basic storage operations.
 
 ### [Error Recovery](/docs/patterns/error-recovery)
 
-**Difficulty**: Intermediate | **Category**: Error Handling | **Status**: Stable
+<span class="sb-badge sb-badge--intermediate">Intermediate</span> <span class="sb-tag sb-tag--error-handling">Error Handling</span> <span class="sb-badge sb-badge--stable">Stable</span>
 
 Comprehensive error handling patterns including Result types, fallback logic, graceful degradation, transaction rollback, and input validation. Essential for production-ready contracts.
 
@@ -32,11 +32,15 @@ Comprehensive error handling patterns including Result types, fallback logic, gr
 
 ### 🪙 Token Standards
 
+<span class="sb-tag sb-tag--token">Token</span>
+
 - Basic token implementations
 - Token wrappers and vaults
 - Multi-token systems
 
 ### 💰 DeFi Patterns
+
+<span class="sb-tag sb-tag--defi">DeFi</span>
 
 - Escrow contracts
 - Atomic swaps
@@ -45,11 +49,15 @@ Comprehensive error handling patterns including Result types, fallback logic, gr
 
 ### 🗳️ Governance
 
+<span class="sb-tag sb-tag--governance">Governance</span>
+
 - Simple voting systems
 - DAO implementations
 - Proposal mechanisms
 
 ### ⚡ Advanced Patterns
+
+<span class="sb-badge sb-badge--advanced">Advanced</span>
 
 - Cross-contract calls
 - Upgradeable contracts

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -146,8 +146,14 @@ const config: Config = {
         },
         blog: false,
         theme: {
-          customCss: ['./src/css/fonts.css', './src/css/custom.css', './src/css/breakpoints.css', './src/css/design-tokens.css','./src/css/design-tokens.css',
-            './src/css/search-experience.css',]
+          customCss: [
+            './src/css/fonts.css',
+            './src/css/design-tokens.css',
+            './src/css/breakpoints.css',
+            './src/css/badges-tags.css',
+            './src/css/custom.css',
+            './src/css/search-experience.css',
+          ]
         },
       } satisfies Preset.Options,
     ],

--- a/documentation/src/components/Badge/Badge.tsx
+++ b/documentation/src/components/Badge/Badge.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import clsx from 'clsx';
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export type BadgeDifficulty = 'beginner' | 'intermediate' | 'advanced';
+export type BadgeStatus = 'new' | 'updated' | 'coming-soon' | 'deprecated' | 'stable' | 'experimental' | 'draft';
+export type TagCategory = 'token' | 'defi' | 'nft' | 'security' | 'storage' | 'auth' | 'governance' | 'error-handling';
+export type BadgeSize = 'sm' | 'md' | 'lg';
+
+type BadgeVariant = BadgeDifficulty | BadgeStatus;
+
+export interface BadgeProps {
+  /** Difficulty or status variant */
+  variant: BadgeVariant;
+  /** Size — defaults to 'md' */
+  size?: BadgeSize;
+  /** Make the badge interactive (adds cursor + hover/focus styles) */
+  clickable?: boolean;
+  /** Accessible label override (use when badge is the only indicator) */
+  'aria-label'?: string;
+  /** Render as a role="status" element */
+  asStatus?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export interface TagProps {
+  /** Category variant */
+  variant: TagCategory;
+  /** Size — defaults to 'md' */
+  size?: BadgeSize;
+  /** Make the tag interactive */
+  clickable?: boolean;
+  /** Render as <button> or <a> when clickable */
+  as?: 'span' | 'button' | 'a';
+  href?: string;
+  className?: string;
+  children?: React.ReactNode;
+  onClick?: React.MouseEventHandler;
+}
+
+// ── Badge ─────────────────────────────────────────────────────────────────
+
+/**
+ * Badge — pill-shaped status/difficulty indicator.
+ *
+ * Uses global `.sb-badge` classes from badges-tags.css.
+ *
+ * @example
+ * <Badge variant="beginner" />
+ * <Badge variant="new" size="sm" />
+ * <Badge variant="stable" size="lg" />
+ */
+export function Badge({
+  variant,
+  size = 'md',
+  clickable = false,
+  asStatus = false,
+  className,
+  children,
+  'aria-label': ariaLabel,
+}: BadgeProps) {
+  const label = children ?? variant;
+  return (
+    <span
+      className={clsx(
+        'sb-badge',
+        `sb-badge--${variant}`,
+        size !== 'md' && `sb-badge--${size}`,
+        clickable && 'sb-badge--clickable',
+        className,
+      )}
+      role={asStatus ? 'status' : undefined}
+      aria-label={ariaLabel}
+    >
+      {label}
+    </span>
+  );
+}
+
+// ── Tag ───────────────────────────────────────────────────────────────────
+
+/**
+ * Tag — rounded-rectangle category label.
+ *
+ * Uses global `.sb-tag` classes from badges-tags.css.
+ *
+ * @example
+ * <Tag variant="storage" />
+ * <Tag variant="defi" size="sm" />
+ * <Tag variant="token" clickable as="button" onClick={...} />
+ */
+export function Tag({
+  variant,
+  size = 'md',
+  clickable = false,
+  as: As = 'span',
+  href,
+  className,
+  children,
+  onClick,
+}: TagProps) {
+  const label = children ?? variant;
+  const Element = href ? 'a' : As;
+  return (
+    <Element
+      href={href}
+      onClick={onClick}
+      className={clsx(
+        'sb-tag',
+        `sb-tag--${variant}`,
+        size !== 'md' && `sb-tag--${size}`,
+        clickable && 'sb-tag--clickable',
+        className,
+      )}
+    >
+      {label}
+    </Element>
+  );
+}

--- a/documentation/src/components/Badge/index.ts
+++ b/documentation/src/components/Badge/index.ts
@@ -1,0 +1,2 @@
+export { Badge, Tag } from './Badge';
+export type { BadgeProps, TagProps, BadgeDifficulty, BadgeStatus, TagCategory, BadgeSize } from './Badge';

--- a/documentation/src/components/PatternDoc/PatternDoc.tsx
+++ b/documentation/src/components/PatternDoc/PatternDoc.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import clsx from 'clsx';
 import styles from './PatternDoc.module.css';
+import { Badge, Tag } from '../Badge';
+import type { BadgeDifficulty, BadgeStatus, TagCategory } from '../Badge';
 
 export type PatternMetaProps = {
   slug: string;
-  difficulty: 'beginner' | 'intermediate' | 'advanced';
-  category: string;
-  status?: 'draft' | 'stable' | 'experimental';
+  difficulty: BadgeDifficulty;
+  category: TagCategory | string;
+  status?: BadgeStatus;
   lastReviewed?: string;
 };
 
@@ -20,7 +22,8 @@ export function PatternMeta({
   return (
     <div className={styles.metaCard} data-pattern-slug={slug}>
       <div className={styles.metaHeader}>
-        <span className={clsx(styles.badge, styles[`badge${difficulty}`])}>{difficulty}</span>
+        <Badge variant={difficulty} size="md" asStatus />
+        {status && status !== 'stable' && <Badge variant={status} size="sm" />}
       </div>
       <dl className={styles.metaGrid}>
         <div>

--- a/documentation/src/components/cards/PatternCard.tsx
+++ b/documentation/src/components/cards/PatternCard.tsx
@@ -2,6 +2,7 @@ import React, { useState, type ReactNode } from 'react';
 import clsx from 'clsx';
 import BaseCard from './BaseCard';
 import styles from './cards.module.css';
+import { Tag } from '../Badge';
 
 export interface PatternCardProps {
   contractName: string;
@@ -42,7 +43,7 @@ export default function PatternCard({
       <div className={styles.patternHeader}>
         {icon && <span className={styles.patternIcon}>{icon}</span>}
         <span className={styles.patternBadge}>SOROBAN CONTRACT</span>
-        <span className={styles.patternTag}>{tag}</span>
+        <Tag variant="storage" size="sm">{tag}</Tag>
       </div>
 
       {/* Contract name — monospace, feels like code */}

--- a/documentation/src/css/badges-tags.css
+++ b/documentation/src/css/badges-tags.css
@@ -1,0 +1,240 @@
+/**
+ * Badges & Tags — Canonical Global Styles
+ *
+ * Provides .sb-badge and .sb-tag utility classes consumed by:
+ *   - React components (Badge.tsx)
+ *   - MDX docs pages (raw HTML class usage)
+ *   - PatternDoc, PatternCard, and any future components
+ *
+ * All color values come from design-tokens.css via CSS custom properties.
+ * Dark mode is handled automatically via [data-theme='dark'] overrides in
+ * design-tokens.css — no extra selectors needed here.
+ */
+
+/* ── Base: Badge (pill) ──────────────────────────────────────────────────── */
+
+.sb-badge {
+  display: inline-flex;
+  align-items: center;
+  height: var(--sb-badge-height-md);
+  padding-inline: var(--sb-badge-px-md);
+  font-size: var(--sb-badge-font-md);
+  font-weight: var(--sb-badge-font-weight);
+  letter-spacing: var(--sb-badge-letter-spacing);
+  line-height: 1;
+  border-radius: var(--sb-badge-radius);
+  border: 1px solid transparent;
+  white-space: nowrap;
+  user-select: none;
+  vertical-align: middle;
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+/* ── Base: Tag (rounded rectangle) ──────────────────────────────────────── */
+
+.sb-tag {
+  display: inline-flex;
+  align-items: center;
+  height: var(--sb-badge-height-md);
+  padding-inline: var(--sb-badge-px-md);
+  font-size: var(--sb-badge-font-md);
+  font-weight: var(--sb-tag-font-weight);
+  line-height: 1;
+  border-radius: var(--sb-tag-radius);
+  border: 1px solid transparent;
+  white-space: nowrap;
+  user-select: none;
+  vertical-align: middle;
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+/* ── Size Modifiers ──────────────────────────────────────────────────────── */
+
+.sb-badge--sm,
+.sb-tag--sm {
+  height: var(--sb-badge-height-sm);
+  padding-inline: var(--sb-badge-px-sm);
+  font-size: var(--sb-badge-font-sm);
+}
+
+.sb-badge--md,
+.sb-tag--md {
+  height: var(--sb-badge-height-md);
+  padding-inline: var(--sb-badge-px-md);
+  font-size: var(--sb-badge-font-md);
+}
+
+.sb-badge--lg,
+.sb-tag--lg {
+  height: var(--sb-badge-height-lg);
+  padding-inline: var(--sb-badge-px-lg);
+  font-size: var(--sb-badge-font-lg);
+}
+
+/* ── Difficulty Variants ─────────────────────────────────────────────────── */
+
+.sb-badge--beginner {
+  background-color: var(--sb-badge-beginner-bg);
+  color: var(--sb-badge-beginner-text);
+  border-color: var(--sb-badge-beginner-border);
+}
+
+.sb-badge--intermediate {
+  background-color: var(--sb-badge-intermediate-bg);
+  color: var(--sb-badge-intermediate-text);
+  border-color: var(--sb-badge-intermediate-border);
+}
+
+.sb-badge--advanced {
+  background-color: var(--sb-badge-advanced-bg);
+  color: var(--sb-badge-advanced-text);
+  border-color: var(--sb-badge-advanced-border);
+}
+
+/* ── Status Variants ─────────────────────────────────────────────────────── */
+
+.sb-badge--new {
+  background-color: var(--sb-badge-new-bg);
+  color: var(--sb-badge-new-text);
+  border-color: var(--sb-badge-new-border);
+}
+
+.sb-badge--updated {
+  background-color: var(--sb-badge-updated-bg);
+  color: var(--sb-badge-updated-text);
+  border-color: var(--sb-badge-updated-border);
+}
+
+.sb-badge--coming-soon {
+  background-color: var(--sb-badge-coming-soon-bg);
+  color: var(--sb-badge-coming-soon-text);
+  border-color: var(--sb-badge-coming-soon-border);
+}
+
+.sb-badge--deprecated {
+  background-color: var(--sb-badge-deprecated-bg);
+  color: var(--sb-badge-deprecated-text);
+  border-color: var(--sb-badge-deprecated-border);
+}
+
+.sb-badge--stable {
+  background-color: var(--sb-badge-stable-bg);
+  color: var(--sb-badge-stable-text);
+  border-color: var(--sb-badge-stable-border);
+}
+
+.sb-badge--experimental {
+  background-color: var(--sb-badge-experimental-bg);
+  color: var(--sb-badge-experimental-text);
+  border-color: var(--sb-badge-experimental-border);
+}
+
+.sb-badge--draft {
+  background-color: var(--sb-badge-draft-bg);
+  color: var(--sb-badge-draft-text);
+  border-color: var(--sb-badge-draft-border);
+}
+
+/* ── Category Tag Variants ───────────────────────────────────────────────── */
+
+.sb-tag--token {
+  background-color: var(--sb-tag-token-bg);
+  color: var(--sb-tag-token-text);
+}
+
+.sb-tag--defi {
+  background-color: var(--sb-tag-defi-bg);
+  color: var(--sb-tag-defi-text);
+}
+
+.sb-tag--nft {
+  background-color: var(--sb-tag-nft-bg);
+  color: var(--sb-tag-nft-text);
+}
+
+.sb-tag--security {
+  background-color: var(--sb-tag-security-bg);
+  color: var(--sb-tag-security-text);
+}
+
+.sb-tag--storage {
+  background-color: var(--sb-tag-storage-bg);
+  color: var(--sb-tag-storage-text);
+}
+
+.sb-tag--auth {
+  background-color: var(--sb-tag-auth-bg);
+  color: var(--sb-tag-auth-text);
+}
+
+.sb-tag--governance {
+  background-color: var(--sb-tag-governance-bg);
+  color: var(--sb-tag-governance-text);
+}
+
+.sb-tag--error-handling {
+  background-color: var(--sb-tag-error-handling-bg);
+  color: var(--sb-tag-error-handling-text);
+}
+
+/* ── Interactive (clickable) Modifier ────────────────────────────────────── */
+
+.sb-badge--clickable,
+.sb-tag--clickable {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.sb-badge--clickable:hover,
+.sb-tag--clickable:hover {
+  transform: translateY(-1px);
+  filter: brightness(0.95);
+}
+
+.sb-badge--clickable:active,
+.sb-tag--clickable:active {
+  transform: translateY(0);
+  filter: brightness(0.9);
+}
+
+.sb-badge--clickable:focus-visible,
+.sb-tag--clickable:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
+/* ── Badge/Tag Group ─────────────────────────────────────────────────────── */
+
+.sb-badge-group,
+.sb-tag-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem; /* 6px */
+}
+
+/* ── Responsive: shrink to sm on narrow viewports ────────────────────────── */
+
+@media (max-width: 480px) {
+  .sb-badge,
+  .sb-tag {
+    height: var(--sb-badge-height-sm);
+    padding-inline: var(--sb-badge-px-sm);
+    font-size: var(--sb-badge-font-sm);
+  }
+}
+
+/* ── Reduced motion ──────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .sb-badge,
+  .sb-tag {
+    transition: none;
+  }
+}

--- a/documentation/src/css/design-tokens.css
+++ b/documentation/src/css/design-tokens.css
@@ -227,6 +227,99 @@
   --gutter-lg: 2rem; /* 32px */
   --gutter-xl: 3rem; /* 48px */
 
+  /* ══════════════════════════════════════════════════════════════════════
+      BADGE & TAG TOKENS
+      ══════════════════════════════════════════════════════════════════════ */
+
+  /* Base shape */
+  --sb-badge-radius: 9999px;
+  --sb-tag-radius: var(--radius-md); /* 6px */
+  --sb-badge-font-weight: 600;
+  --sb-tag-font-weight: 500;
+  --sb-badge-letter-spacing: 0.01em;
+
+  /* Size — sm */
+  --sb-badge-height-sm: 1.25rem;   /* 20px */
+  --sb-badge-px-sm: 0.375rem;      /* 6px */
+  --sb-badge-font-sm: 0.6875rem;   /* 11px */
+
+  /* Size — md (default) */
+  --sb-badge-height-md: 1.5rem;    /* 24px */
+  --sb-badge-px-md: 0.5rem;        /* 8px */
+  --sb-badge-font-md: 0.75rem;     /* 12px */
+
+  /* Size — lg */
+  --sb-badge-height-lg: 1.75rem;   /* 28px */
+  --sb-badge-px-lg: 0.75rem;       /* 12px */
+  --sb-badge-font-lg: 0.8125rem;   /* 13px */
+
+  /* Difficulty — light mode */
+  --sb-badge-beginner-bg:          rgba(34, 197, 94, 0.15);
+  --sb-badge-beginner-text:        #15803d;
+  --sb-badge-beginner-border:      rgba(34, 197, 94, 0.35);
+
+  --sb-badge-intermediate-bg:      rgba(245, 158, 11, 0.15);
+  --sb-badge-intermediate-text:    #b45309;
+  --sb-badge-intermediate-border:  rgba(245, 158, 11, 0.35);
+
+  --sb-badge-advanced-bg:          rgba(239, 68, 68, 0.12);
+  --sb-badge-advanced-text:        #b91c1c;
+  --sb-badge-advanced-border:      rgba(239, 68, 68, 0.3);
+
+  /* Status — light mode */
+  --sb-badge-new-bg:               #16a34a;
+  --sb-badge-new-text:             #ffffff;
+  --sb-badge-new-border:           #15803d;
+
+  --sb-badge-updated-bg:           #2563eb;
+  --sb-badge-updated-text:         #ffffff;
+  --sb-badge-updated-border:       #1d4ed8;
+
+  --sb-badge-coming-soon-bg:       transparent;
+  --sb-badge-coming-soon-text:     #6b7280;
+  --sb-badge-coming-soon-border:   #d1d5db;
+
+  --sb-badge-deprecated-bg:        #dc2626;
+  --sb-badge-deprecated-text:      #ffffff;
+  --sb-badge-deprecated-border:    #b91c1c;
+
+  --sb-badge-stable-bg:            #0891b2;
+  --sb-badge-stable-text:          #ffffff;
+  --sb-badge-stable-border:        #0e7490;
+
+  --sb-badge-experimental-bg:      rgba(168, 85, 247, 0.15);
+  --sb-badge-experimental-text:    #7e22ce;
+  --sb-badge-experimental-border:  rgba(168, 85, 247, 0.35);
+
+  --sb-badge-draft-bg:             rgba(107, 114, 128, 0.12);
+  --sb-badge-draft-text:           #4b5563;
+  --sb-badge-draft-border:         rgba(107, 114, 128, 0.3);
+
+  /* Category tags — light mode */
+  --sb-tag-token-bg:               var(--color-primary-100);
+  --sb-tag-token-text:             var(--color-primary-700);
+
+  --sb-tag-defi-bg:                var(--color-secondary-100);
+  --sb-tag-defi-text:              var(--color-secondary-700);
+
+  --sb-tag-nft-bg:                 rgba(6, 182, 212, 0.12);
+  --sb-tag-nft-text:               #0e7490;
+
+  --sb-tag-security-bg:            rgba(239, 68, 68, 0.1);
+  --sb-tag-security-text:          #b91c1c;
+
+  --sb-tag-storage-bg:             rgba(245, 158, 11, 0.12);
+  --sb-tag-storage-text:           #b45309;
+
+  --sb-tag-auth-bg:                var(--color-gray-100);
+  --sb-tag-auth-text:              var(--color-gray-700);
+
+  --sb-tag-governance-bg:          rgba(168, 85, 247, 0.1);
+  --sb-tag-governance-text:        #7e22ce;
+
+  --sb-tag-error-handling-bg:      rgba(239, 68, 68, 0.1);
+  --sb-tag-error-handling-text:    #b91c1c;
+
   /* Default semantic colors */
   --color-text-primary: var(--color-gray-900);
   --color-text-secondary: var(--color-gray-700);
@@ -331,6 +424,66 @@
 
   /* Dark mode semantic colors */
   --color-text-primary: var(--color-gray-50);
+
+  /* Badge & Tag — dark mode overrides */
+  --sb-badge-beginner-bg:          rgba(74, 222, 128, 0.15);
+  --sb-badge-beginner-text:        #4ade80;
+  --sb-badge-beginner-border:      rgba(74, 222, 128, 0.3);
+
+  --sb-badge-intermediate-bg:      rgba(251, 191, 36, 0.15);
+  --sb-badge-intermediate-text:    #fbbf24;
+  --sb-badge-intermediate-border:  rgba(251, 191, 36, 0.3);
+
+  --sb-badge-advanced-bg:          rgba(248, 113, 113, 0.15);
+  --sb-badge-advanced-text:        #f87171;
+  --sb-badge-advanced-border:      rgba(248, 113, 113, 0.3);
+
+  --sb-badge-new-bg:               #15803d;
+  --sb-badge-new-border:           #166534;
+
+  --sb-badge-updated-bg:           #1d4ed8;
+  --sb-badge-updated-border:       #1e40af;
+
+  --sb-badge-coming-soon-text:     #9ca3af;
+  --sb-badge-coming-soon-border:   #374151;
+
+  --sb-badge-deprecated-bg:        #b91c1c;
+  --sb-badge-deprecated-border:    #991b1b;
+
+  --sb-badge-stable-bg:            #0e7490;
+  --sb-badge-stable-border:        #155e75;
+
+  --sb-badge-experimental-bg:      rgba(192, 132, 252, 0.15);
+  --sb-badge-experimental-text:    #c084fc;
+  --sb-badge-experimental-border:  rgba(192, 132, 252, 0.3);
+
+  --sb-badge-draft-bg:             rgba(156, 163, 175, 0.12);
+  --sb-badge-draft-text:           #9ca3af;
+  --sb-badge-draft-border:         rgba(156, 163, 175, 0.25);
+
+  --sb-tag-token-bg:               rgba(96, 165, 250, 0.15);
+  --sb-tag-token-text:             #93c5fd;
+
+  --sb-tag-defi-bg:                rgba(192, 132, 252, 0.15);
+  --sb-tag-defi-text:              #d8b4fe;
+
+  --sb-tag-nft-bg:                 rgba(34, 211, 238, 0.12);
+  --sb-tag-nft-text:               #67e8f9;
+
+  --sb-tag-security-bg:            rgba(248, 113, 113, 0.12);
+  --sb-tag-security-text:          #fca5a5;
+
+  --sb-tag-storage-bg:             rgba(251, 191, 36, 0.12);
+  --sb-tag-storage-text:           #fcd34d;
+
+  --sb-tag-auth-bg:                rgba(156, 163, 175, 0.12);
+  --sb-tag-auth-text:              #d1d5db;
+
+  --sb-tag-governance-bg:          rgba(192, 132, 252, 0.12);
+  --sb-tag-governance-text:        #d8b4fe;
+
+  --sb-tag-error-handling-bg:      rgba(248, 113, 113, 0.12);
+  --sb-tag-error-handling-text:    #fca5a5;
   --color-text-secondary: var(--color-gray-300);
   --color-text-tertiary: var(--color-gray-500);
   --color-text-inverse: var(--color-gray-900);


### PR DESCRIPTION
Summary

Completes the badge and tag system by moving it from documentation-only guidance into fully implemented, reusable runtime components/styles. This ensures consistent usage across docs pages, cards, and contributor-facing UI.

Why This Matters

Contributors previously had style guidance but no canonical badge/tag implementation to apply consistently. This caused inconsistencies in difficulty, category, and status indicators across the project.

Changes
- Implemented shared badge/tag styles in reusable CSS
- Added size variants: small, medium, large
- Added status, difficulty, and category variants with consistent styling
- Ensured full dark mode compatibility and responsive behavior
- Added real usage examples in at least two production docs pages/components

Impact
- Standardizes badge and tag usage across the platform
- Improves design consistency and contributor experience
- Ensures accessibility and readability across light/dark themes

Acceptance Criteria
- [ ]  Difficulty, category, and status variants render correctly
- [ ]  Small / medium / large size variants implemented and documented
- [ ]  WCAG AA contrast passes in light and dark themes
- [ ]  Examples visible in production docs pages

Closes #31