### PR TITLE
feat: add code example testing framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,10 +183,34 @@ jobs:
           fi
           echo "✅ Workflow syntax validated"
 
+  test-examples:
+    name: Test Code Examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            examples/target
+          key: cargo-examples-${{ hashFiles('examples/**/Cargo.toml') }}
+          restore-keys: |
+            cargo-examples-
+
+      - name: Run example tests
+        run: bash scripts/test-examples.sh
+
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [lint-format, typecheck, build-docs, validate-deployment]
+    needs: [lint-format, typecheck, build-docs, validate-deployment, test-examples]
     if: always()
     steps:
       - name: Check job statuses
@@ -205,6 +229,10 @@ jobs:
           fi
           if [ "${{ needs.validate-deployment.result }}" != "success" ]; then
             echo "❌ Deployment validation failed"
+            exit 1
+          fi
+          if [ "${{ needs.test-examples.result }}" != "success" ]; then
+            echo "❌ Code example tests failed"
             exit 1
           fi
           echo "✅ All CI checks passed"

--- a/documentation/docs/contributing/add-tested-example.md
+++ b/documentation/docs/contributing/add-tested-example.md
@@ -1,0 +1,161 @@
+---
+title: Adding a Tested Code Example
+description: How to contribute a new Soroban code example that is validated automatically by CI.
+sidebar_position: 2
+---
+
+# Adding a Tested Code Example
+
+Every code example in the Soroban Cookbook lives in the `examples/` directory at the root of the repository. Each example is a self-contained Rust crate with its own `Cargo.toml` and `src/lib.rs`. The CI pipeline runs `cargo test` for every example on every pull request, so all published snippets are always verified.
+
+## Directory layout
+
+```
+examples/
+├── Cargo.toml          ← workspace manifest (lists all examples)
+├── hello-world/
+│   ├── Cargo.toml
+│   └── src/
+│       └── lib.rs      ← contract code + #[cfg(test)] module
+├── counter/
+│   ├── Cargo.toml
+│   └── src/
+│       └── lib.rs
+└── <your-example>/
+    ├── Cargo.toml
+    └── src/
+        └── lib.rs
+```
+
+## Step-by-step guide
+
+### 1. Create the example directory
+
+Pick a short, kebab-case name that matches the documentation page it supports:
+
+```bash
+mkdir -p examples/<your-example>/src
+```
+
+### 2. Write `Cargo.toml`
+
+Copy the template below and replace `<your-example>` with your directory name:
+
+```toml
+[package]
+name = "<your-example>"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+```
+
+### 3. Write `src/lib.rs`
+
+Include the contract implementation **and** a `#[cfg(test)]` module with at least one test per public function. Use `env.mock_all_auths()` when your functions call `require_auth`.
+
+```rust
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct MyExample;
+
+#[contractimpl]
+impl MyExample {
+    pub fn do_something(env: Env) -> u32 {
+        42
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::Env;
+
+    #[test]
+    fn test_do_something() {
+        let env = Env::default();
+        let id = env.register(MyExample, ());
+        let client = MyExampleClient::new(&env, &id);
+        assert_eq!(client.do_something(), 42);
+    }
+}
+```
+
+### 4. Register in the workspace
+
+Open `examples/Cargo.toml` and add your new crate to the `members` list:
+
+```toml
+[workspace]
+members = [
+    "hello-world",
+    "counter",
+    "token-transfer",
+    "<your-example>",   # ← add this line
+]
+resolver = "2"
+```
+
+### 5. Run locally before pushing
+
+```bash
+# Test only your new example
+./scripts/test-examples.sh <your-example>
+
+# Test all examples
+./scripts/test-examples.sh
+```
+
+Both commands print a clear pass/fail result for each crate.
+
+### 6. Link to the docs
+
+In your documentation page (`.md` or `.mdx`), reference the example naturally in code fences. The tested source in `examples/` is the source of truth; keep the two in sync.
+
+## CI integration
+
+The `test-examples` job in `.github/workflows/ci.yml` runs `./scripts/test-examples.sh` on every pull request and push to `main`. A failing example blocks the PR from merging.
+
+If your PR introduces a new example, CI will automatically pick it up because the script discovers every sub-directory in `examples/` that contains a `Cargo.toml`.
+
+## Checklist before submitting
+
+- [ ] `examples/<your-example>/Cargo.toml` exists and lists `soroban-sdk` as a dependency
+- [ ] `examples/<your-example>/src/lib.rs` compiles with `cargo build`
+- [ ] Every public function has at least one test in `#[cfg(test)]`
+- [ ] `cargo test --manifest-path examples/<your-example>/Cargo.toml` exits 0
+- [ ] `<your-example>` is listed in `examples/Cargo.toml`
+- [ ] The documentation page references the same code
+
+## Troubleshooting
+
+**`cargo` not found**
+Install Rust: https://www.rust-lang.org/tools/install
+
+**`soroban_sdk` version mismatch**
+Check the latest version on [crates.io](https://crates.io/crates/soroban-sdk) and update `Cargo.toml` accordingly.
+
+**Test compilation errors**
+Make sure `[lib] crate-type` includes `"rlib"`. Without it, the test harness cannot link the crate.
+
+**`env.register` vs `env.register_contract`**
+Use `env.register(MyContract, ())` (SDK ≥ 21). The older `env.register_contract` was removed in recent releases.

--- a/documentation/sidebars.ts
+++ b/documentation/sidebars.ts
@@ -17,6 +17,7 @@ const sidebars: SidebarsConfig = {
         'getting-started/deploy-testnet',
         'getting-started/contract-interaction',
         'contributing',
+        'contributing/add-tested-example',
       ],
     },
     {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,7 @@
+[workspace]
+members = [
+    "hello-world",
+    "counter",
+    "token-transfer",
+]
+resolver = "2"

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "counter"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -1,0 +1,86 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+const COUNTER_KEY: &str = "count";
+
+#[contract]
+pub struct Counter;
+
+#[contractimpl]
+impl Counter {
+    /// Increment the counter by one and return the new value.
+    pub fn increment(env: Env) -> u32 {
+        let count: u32 = env
+            .storage()
+            .instance()
+            .get(&COUNTER_KEY)
+            .unwrap_or(0);
+        let new_count = count + 1;
+        env.storage().instance().set(&COUNTER_KEY, &new_count);
+        new_count
+    }
+
+    /// Return the current counter value without modifying state.
+    pub fn get(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&COUNTER_KEY)
+            .unwrap_or(0)
+    }
+
+    /// Reset the counter to zero.
+    pub fn reset(env: Env) {
+        env.storage().instance().set(&COUNTER_KEY, &0_u32);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::Env;
+
+    #[test]
+    fn test_initial_value_is_zero() {
+        let env = Env::default();
+        let contract_id = env.register(Counter, ());
+        let client = CounterClient::new(&env, &contract_id);
+
+        assert_eq!(client.get(), 0);
+    }
+
+    #[test]
+    fn test_increment_increases_count() {
+        let env = Env::default();
+        let contract_id = env.register(Counter, ());
+        let client = CounterClient::new(&env, &contract_id);
+
+        assert_eq!(client.increment(), 1);
+        assert_eq!(client.increment(), 2);
+        assert_eq!(client.increment(), 3);
+    }
+
+    #[test]
+    fn test_reset_returns_to_zero() {
+        let env = Env::default();
+        let contract_id = env.register(Counter, ());
+        let client = CounterClient::new(&env, &contract_id);
+
+        client.increment();
+        client.increment();
+        assert_eq!(client.get(), 2);
+
+        client.reset();
+        assert_eq!(client.get(), 0);
+    }
+
+    #[test]
+    fn test_get_does_not_change_state() {
+        let env = Env::default();
+        let contract_id = env.register(Counter, ());
+        let client = CounterClient::new(&env, &contract_id);
+
+        client.increment();
+        assert_eq!(client.get(), 1);
+        assert_eq!(client.get(), 1);
+    }
+}

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "hello-world"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -1,0 +1,52 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, String};
+
+#[contract]
+pub struct HelloWorld;
+
+#[contractimpl]
+impl HelloWorld {
+    /// Return a greeting stored in instance storage, or a default greeting.
+    pub fn hello(env: Env) -> String {
+        env.storage()
+            .instance()
+            .get(&"msg")
+            .unwrap_or(String::from_str(&env, "Hello, Soroban!"))
+    }
+
+    /// Store a custom greeting message.
+    pub fn set_message(env: Env, message: String) {
+        env.storage().instance().set(&"msg", &message);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::Env;
+
+    #[test]
+    fn test_default_greeting() {
+        let env = Env::default();
+        let contract_id = env.register(HelloWorld, ());
+        let client = HelloWorldClient::new(&env, &contract_id);
+
+        assert_eq!(
+            client.hello(),
+            String::from_str(&env, "Hello, Soroban!")
+        );
+    }
+
+    #[test]
+    fn test_custom_greeting() {
+        let env = Env::default();
+        let contract_id = env.register(HelloWorld, ());
+        let client = HelloWorldClient::new(&env, &contract_id);
+
+        client.set_message(&String::from_str(&env, "Greetings from Soroban!"));
+        assert_eq!(
+            client.hello(),
+            String::from_str(&env, "Greetings from Soroban!")
+        );
+    }
+}

--- a/examples/token-transfer/Cargo.toml
+++ b/examples/token-transfer/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "token-transfer"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/examples/token-transfer/src/lib.rs
+++ b/examples/token-transfer/src/lib.rs
@@ -1,0 +1,150 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Env, Address};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Balance(Address),
+}
+
+#[derive(Debug, PartialEq)]
+#[contracttype]
+pub enum Error {
+    InsufficientBalance = 1,
+    InvalidAmount = 2,
+    SelfTransfer = 3,
+}
+
+#[contract]
+pub struct TokenTransfer;
+
+#[contractimpl]
+impl TokenTransfer {
+    /// Mint tokens to an address (for testing purposes).
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let key = DataKey::Balance(to.clone());
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage().persistent().set(&key, &(current + amount));
+    }
+
+    /// Return the balance of an address.
+    pub fn balance(env: Env, of: Address) -> i128 {
+        let key = DataKey::Balance(of);
+        env.storage().persistent().get(&key).unwrap_or(0)
+    }
+
+    /// Transfer tokens from one address to another.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) -> Result<(), Error> {
+        from.require_auth();
+
+        if amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        if from == to {
+            return Err(Error::SelfTransfer);
+        }
+
+        let from_key = DataKey::Balance(from.clone());
+        let from_balance: i128 = env.storage().persistent().get(&from_key).unwrap_or(0);
+
+        if from_balance < amount {
+            return Err(Error::InsufficientBalance);
+        }
+
+        let to_key = DataKey::Balance(to.clone());
+        let to_balance: i128 = env.storage().persistent().get(&to_key).unwrap_or(0);
+
+        env.storage()
+            .persistent()
+            .set(&from_key, &(from_balance - amount));
+        env.storage()
+            .persistent()
+            .set(&to_key, &(to_balance + amount));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    fn setup() -> (Env, soroban_sdk::Address, TokenTransferClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TokenTransfer, ());
+        let client = TokenTransferClient::new(&env, &contract_id);
+        (env, contract_id, client)
+    }
+
+    #[test]
+    fn test_mint_increases_balance() {
+        let (env, _, client) = setup();
+        let alice = Address::generate(&env);
+
+        client.mint(&alice, &500);
+        assert_eq!(client.balance(&alice), 500);
+    }
+
+    #[test]
+    fn test_transfer_moves_tokens() {
+        let (env, _, client) = setup();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.mint(&alice, &1000);
+        client.transfer(&alice, &bob, &400);
+
+        assert_eq!(client.balance(&alice), 600);
+        assert_eq!(client.balance(&bob), 400);
+    }
+
+    #[test]
+    fn test_transfer_fails_on_insufficient_balance() {
+        let (env, _, client) = setup();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.mint(&alice, &100);
+        let result = client.try_transfer(&alice, &bob, &200);
+
+        assert_eq!(result, Err(Ok(Error::InsufficientBalance)));
+        // Verify state rolled back
+        assert_eq!(client.balance(&alice), 100);
+        assert_eq!(client.balance(&bob), 0);
+    }
+
+    #[test]
+    fn test_transfer_fails_on_invalid_amount() {
+        let (env, _, client) = setup();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.mint(&alice, &100);
+        let result = client.try_transfer(&alice, &bob, &0);
+        assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+
+        let result = client.try_transfer(&alice, &bob, &-50);
+        assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+    }
+
+    #[test]
+    fn test_self_transfer_is_rejected() {
+        let (env, _, client) = setup();
+        let alice = Address::generate(&env);
+
+        client.mint(&alice, &100);
+        let result = client.try_transfer(&alice, &alice, &50);
+        assert_eq!(result, Err(Ok(Error::SelfTransfer)));
+    }
+
+    #[test]
+    fn test_initial_balance_is_zero() {
+        let (env, _, client) = setup();
+        let alice = Address::generate(&env);
+
+        assert_eq!(client.balance(&alice), 0);
+    }
+}

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# test-examples.sh — Validate all Soroban code examples compile and their tests pass.
+#
+# Usage:
+#   ./scripts/test-examples.sh           # test all examples
+#   ./scripts/test-examples.sh counter   # test a single example by directory name
+#
+# Exit codes:
+#   0 — all examples passed
+#   1 — one or more examples failed
+
+set -euo pipefail
+
+EXAMPLES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../examples" && pwd)"
+PASS=0
+FAIL=0
+FAILED_EXAMPLES=()
+
+# Colours (disabled when not writing to a terminal)
+if [ -t 1 ]; then
+  GREEN="\033[0;32m"
+  RED="\033[0;31m"
+  YELLOW="\033[0;33m"
+  RESET="\033[0m"
+else
+  GREEN=""
+  RED=""
+  YELLOW=""
+  RESET=""
+fi
+
+log_info()  { echo -e "${YELLOW}[info]${RESET}  $*"; }
+log_pass()  { echo -e "${GREEN}[pass]${RESET}  $*"; }
+log_fail()  { echo -e "${RED}[fail]${RESET}  $*"; }
+
+# ── prerequisite checks ───────────────────────────────────────────────────────
+
+if ! command -v cargo &>/dev/null; then
+  echo "ERROR: cargo is not installed or not on PATH." >&2
+  echo "Install Rust: https://www.rust-lang.org/tools/install" >&2
+  exit 1
+fi
+
+# ── determine which examples to run ──────────────────────────────────────────
+
+if [ $# -gt 0 ]; then
+  # Single example requested
+  EXAMPLE_DIRS=("$EXAMPLES_DIR/$1")
+  if [ ! -d "${EXAMPLE_DIRS[0]}" ]; then
+    echo "ERROR: Example '${1}' not found in ${EXAMPLES_DIR}" >&2
+    exit 1
+  fi
+else
+  # Collect every sub-directory that contains a Cargo.toml (i.e. every example)
+  mapfile -t EXAMPLE_DIRS < <(find "$EXAMPLES_DIR" -mindepth 1 -maxdepth 1 -type d | sort)
+fi
+
+echo ""
+log_info "Running tests for ${#EXAMPLE_DIRS[@]} example(s) in ${EXAMPLES_DIR}"
+echo ""
+
+# ── run tests ─────────────────────────────────────────────────────────────────
+
+for dir in "${EXAMPLE_DIRS[@]}"; do
+  name="$(basename "$dir")"
+
+  # Skip the workspace root itself
+  [ -f "$dir/Cargo.toml" ] || continue
+
+  log_info "Testing '${name}' …"
+
+  if cargo test --manifest-path "$dir/Cargo.toml" 2>&1; then
+    log_pass "'${name}' — all tests passed"
+    (( PASS++ )) || true
+  else
+    log_fail "'${name}' — tests FAILED"
+    (( FAIL++ )) || true
+    FAILED_EXAMPLES+=("$name")
+  fi
+
+  echo ""
+done
+
+# ── summary ───────────────────────────────────────────────────────────────────
+
+echo "─────────────────────────────────────"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo "─────────────────────────────────────"
+
+if [ "${FAIL}" -gt 0 ]; then
+  echo ""
+  log_fail "The following example(s) failed:"
+  for ex in "${FAILED_EXAMPLES[@]}"; do
+    echo "  • ${ex}"
+  done
+  echo ""
+  echo "Fix the errors above, then re-run: ./scripts/test-examples.sh"
+  exit 1
+fi
+
+echo ""
+log_pass "All examples passed."


### PR DESCRIPTION
## Summary

Closes #63

- Adds an `examples/` workspace at the repo root with three fully-tested Soroban contract examples: **hello-world**, **counter**, and **token-transfer**. Each example is a self-contained Rust crate with a `#[cfg(test)]` module covering every public function.
- Adds `scripts/test-examples.sh` — a shell script that discovers every crate in `examples/` and runs `cargo test`. Supports filtering to a single example by name (e.g. `./scripts/test-examples.sh counter`). Exits non-zero if any example fails.
- Integrates a new `test-examples` CI job in `.github/workflows/ci.yml` that runs the script on every PR and push to `main`. The `summary` job also gates on this new job.
- Adds `documentation/docs/contributing/add-tested-example.md` — a contributor guide explaining how to create a new tested example, register it in the workspace, run it locally, and link it to a documentation page.

## Test plan

- [ ] `./scripts/test-examples.sh` exits 0 locally (requires Rust/cargo)
- [ ] `./scripts/test-examples.sh counter` tests only the counter example
- [ ] CI `test-examples` job passes on this PR
- [ ] `documentation/sidebars.ts` references the new contributor guide page