### PR TITLE
Add mobile-responsive-tables spec

### DIFF
--- a/.kiro/specs/mobile-responsive-tables/.config.kiro
+++ b/.kiro/specs/mobile-responsive-tables/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "930b3e2c-8088-4092-83e8-d5366d2a1c62", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/mobile-responsive-tables/design.md
+++ b/.kiro/specs/mobile-responsive-tables/design.md
@@ -1,0 +1,191 @@
+# Design Document: Mobile Responsive Tables
+
+## Overview
+
+This design document specifies CSS-based responsive table behavior for the Soroban Cookbook documentation site. The feature addresses mobile readability issues with wide tables by providing two responsive modes: horizontal scrolling and stacked card layout.
+
+The implementation leverages existing Infima CSS custom properties (`--ifm-table-*`, `--breakpoint-md`) to minimize maintenance overhead and ensure theme consistency across light/dark modes.
+
+## Architecture
+
+### Design Decisions
+
+The responsive table feature uses a **desktop-first architecture** where base table styles apply at viewport widths ≥768px, with mobile overrides applying below this threshold via CSS media queries. This approach:
+
+- Aligns with Infima's existing CSS architecture
+- Avoids redundant breakpoint definitions
+- Ensures minimal CSS specificity conflicts
+
+### Two Responsive Modes
+
+1. **Horizontal Scroll (Default)**: Tables wrap in a horizontally scrollable container that becomes visible only on mobile viewports
+2. **Card Stack (Optional)**: Transforms table rows into card-style blocks using CSS pseudo-elements for header labels
+
+### Component Hierarchy
+
+```
+Documentation Page
+└── Table Wrapper (.table-responsive)
+    └── HTML Table (native semantic structure)
+        ├── Table Head (thead)
+        ├── Table Body (tbody)
+        │   └── Table Row (tr)
+        │       └── Table Cell (td) + Table Header (th)
+```
+
+## Components and Interfaces
+
+### CSS Custom Properties
+
+The feature introduces no new CSS variables. It reuses existing tokens:
+
+| Token | Purpose | Source |
+|-------|---------|--------|
+| `--breakpoint-md` | Mobile threshold (768px) | Infima |
+| `--ifm-table-border-color` | Table borders | custom.css |
+| `--ifm-table-head-background` | Header background | custom.css |
+| `--ifm-table-stripe-background` | Alternating row background | custom.css |
+| `--ifm-font-color-base` | Text color | Infima |
+| `--ifm-background-color` | Page background | Infima |
+
+### CSS Classes
+
+| Class | Scope | Purpose |
+|-------|-------|---------|
+| `.table-responsive` | Container | Enables horizontal scroll on mobile |
+| `.table-stacked` | Table | Transforms to card layout on mobile |
+
+### Media Query Specification
+
+```css
+/* Mobile-first: apply styles below 768px */
+@media (max-width: 767px) {
+  .table-responsive { /* horizontal scroll styles */ }
+  .table-stacked { /* card layout styles */ }
+}
+```
+
+## Data Models
+
+### Table State Transitions
+
+| State | Viewport | Behavior |
+|-------|----------|----------|
+| Desktop | ≥768px | Standard table layout, no wrapper |
+| Mobile Scroll | <768px | Horizontal overflow container visible |
+| Mobile Stacked | <768px with `.table-stacked` | Card-based row blocks |
+
+### Theme Adaptation
+
+The scroll indicator uses theme-aware shadows:
+
+| Theme | Shadow Color |
+|-------|--------------|
+| Light | `rgba(0, 0, 0, 0.1)` |
+| Dark | `rgba(0, 0, 0, 0.3)` |
+
+This adapts automatically via CSS custom properties that Infima provides for both themes.
+
+---
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system—essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+## Correctness Properties
+
+### Property 1: Horizontal scroll container visibility
+
+*For any* documentation page containing a table wrapped in `.table-responsive`, when the viewport width is less than 768px, the container SHALL enable horizontal scrolling and display a visual scroll indicator.
+
+**Validates: Requirements 1.1, 1.2, 1.4**
+
+### Property 2: Scroll container hidden on desktop
+
+*For any* documentation page containing a table wrapped in `.table-responsive`, when the viewport width is 768px or greater, the container SHALL NOT apply overflow scrolling styles.
+
+**Validates: Requirements 1.3**
+
+### Property 3: Card layout cell labeling
+
+*For any* table with `.table-stacked` class on mobile viewports, each table cell in the body SHALL display a label derived from its corresponding column header using CSS `::before` pseudo-elements.
+
+**Validates: Requirements 2.2**
+
+### Property 4: Card layout breakpoint isolation
+
+*For any* table with `.table-stacked` class, the card transformation styles SHALL NOT apply when the viewport width is 768px or greater.
+
+**Validates: Requirements 2.3**
+
+### Property 5: Theme consistency
+
+*For any* responsive table style applied, the visual appearance (borders, backgrounds, text colors) SHALL use the same CSS custom properties (`--ifm-table-*`) as the base table theme, ensuring consistent light/dark mode support.
+
+**Validates: Requirements 4.1, 4.2, 4.3**
+
+### Property 6: Semantic structure preservation
+
+*For any* responsive table transformation applied (scroll or stacked), the DOM structure of the table elements (thead, tbody, tr, td, th) SHALL remain unchanged for screen reader accessibility.
+
+**Validates: Requirements 6.1**
+
+### Property 7: Reduced motion respect
+
+*For any* responsive table behavior, when the user's system prefers reduced motion (`prefers-reduced-motion: reduce`), the scroll and transition effects SHALL be disabled or use instant timing.
+
+**Validates: Requirements 6.3**
+
+### Property 8: CSS-only implementation
+
+*For any* responsive table functionality, all core responsive behaviors SHALL be implemented using CSS only, with no JavaScript dependencies for detection, wrapping, or transformation.
+
+**Validates: Requirements 7.1, 7.2**
+
+---
+
+## Error Handling
+
+### Handling Strategies
+
+| Scenario | Handling |
+|----------|----------|
+| Missing table headers for card labels | Fall back to column index (e.g., "Column 1") |
+| Malformed table HTML | Browser's native table rendering applies |
+| Very narrow viewports (<320px) | CSS allows natural overflow; containers use min-width |
+
+The feature uses defensive CSS that gracefully degrades to native table behavior when responsive styles cannot be applied.
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+This feature requires both unit tests (for specific examples and edge cases) and property-based tests (for universal properties across all valid inputs).
+
+### Unit Tests
+
+Unit tests verify specific examples and edge cases:
+
+1. **Scroll container rendering**: Verify `.table-responsive` applies `overflow-x: auto` on viewports <768px
+2. **Card layout transformation**: Verify table rows transform to `display: block` with proper borders
+3. **Theme switching**: Verify visual consistency when toggling between light/dark modes
+4. **Reduced motion**: Verify animations disable when `prefers-reduced-motion` is set
+
+### Property-Based Tests
+
+Property-based tests verify universal properties across generated inputs:
+
+1. **For all** viewport widths <768px, horizontal scroll containers enable overflow scrolling
+2. **For all** viewport widths ≥768px, scroll containers have no overflow styles
+3. **For all** theme configurations, responsive styles use existing `--ifm-table-*` tokens
+4. **For all** table structures, semantic DOM elements remain intact after responsive transformation
+
+### Configuration
+
+- Property-based tests: minimum 100 iterations per property
+- Test tagging: `Feature: mobile-responsive-tables, Property N: [description]`
+- Browser compatibility: Chrome, Firefox, Safari, Edge (latest 2 versions)
+
+### Testing Tools
+
+- **Unit tests**: Vitest or Jest with JSDOM for DOM manipulation tests
+- **Visual regression**: Chrome DevTools Device Mode or Playwright for cross-browser testing
+- **CSS validation**: CSS Lint or Stylelint with responsive-suffix rules

--- a/.kiro/specs/mobile-responsive-tables/requirements.md
+++ b/.kiro/specs/mobile-responsive-tables/requirements.md
@@ -1,0 +1,93 @@
+# Requirements Document
+
+## Introduction
+
+This feature enables mobile-responsive tables in the Soroban Cookbook documentation. Currently, table styles are defined in custom.css using Infima's `--ifm-table-*` CSS custom properties. Wide tables may overflow on mobile devices without proper responsive handling. The feature will add CSS-based responsive behavior using either horizontal scrolling or card-based stacked layouts at mobile breakpoints.
+
+## Glossary
+
+- **Mobile_Viewport**: A browser viewport with width less than 768px (the `md` breakpoint)
+- **Wide_Table**: A table with total column width exceeding the mobile viewport width
+- **Scrollable_Table**: A table container with horizontal overflow scroll enabled
+- **Stacked_Table**: A table transformed into a card-based layout where each row becomes a card on mobile
+- **Breakpoint**: A CSS media query width threshold where responsive behavior changes
+
+## Requirements
+
+### Requirement 1: Horizontal Scroll Container
+
+**User Story:** As a mobile reader, I want to view wide tables without horizontal page overflow, so that I can scroll horizontally within the table to see all columns.
+
+#### Acceptance Criteria
+
+1. THE Documentation_Site SHALL wrap tables in a horizontally scrollable container on mobile viewports
+2. WHEN a table exceeds the mobile viewport width, THE Scroll_Container SHALL enable horizontal scrolling
+3. THE Scroll_Container SHALL remain hidden on viewports 768px and wider
+4. THE Scroll_Container SHALL have a visual indicator (shadow or border) when horizontal scroll is available
+
+### Requirement 2: Mobile Card Layout Alternative
+
+**User Story:** As a mobile reader, I want tables displayed as stacked cards for better readability, so that I can scan information without horizontal scrolling.
+
+#### Acceptance Criteria
+
+1. WHERE mobile card layout is enabled, THE Table_Transform SHALL convert table rows into card-style blocks
+2. WHILE card layout is active, THE Table_Cell SHALL display with a label derived from the table header
+3. THE Card_Layout SHALL apply only on viewports narrower than 768px
+4. THE Card_Layout SHALL maintain proper spacing and border styling from the base table theme
+
+### Requirement 3: Breakpoint Configuration
+
+**User Story:** As a developer, I want configurable breakpoints for table responsiveness, so that I can tune the behavior for different screen sizes.
+
+#### Acceptance Criteria
+
+1. THE CSS SHALL use the existing breakpoint token `--breakpoint-md` (768px) as the mobile threshold
+2. THE Mobile_Styles SHALL apply using a `min-width` media query of 768px to provide desktop-first base styles
+
+### Requirement 4: Light and Dark Mode Support
+
+**User Story:** As a reader, I want tables to remain readable in both light and dark themes, so that I have a consistent experience regardless of system theme.
+
+#### Acceptance Criteria
+
+1. THE Mobile_Table_Styles SHALL work with existing light mode table colors defined in `--ifm-table-*` tokens
+2. THE Mobile_Table_Styles SHALL work with existing dark mode table colors defined in `--ifm-table-*` tokens
+3. THE Scroll_Indicator SHALL adapt to theme (light shadow on light mode, dark shadow on dark mode)
+
+### Requirement 5: Test on Gas and Resources Document
+
+**User Story:** As a reviewer, I want the mobile-responsive tables tested on the gas-and-resources document, so that I can verify the feature works on real documentation tables.
+
+#### Acceptance Criteria
+
+1. THE Responsive_Styles SHALL be tested against tables in `docs/concepts/gas-and-resources.md`
+2. WHEN gas-and-resources tables are viewed on mobile, THE Content SHALL be accessible via scroll or card layout
+
+### Requirement 6: Accessibility Compliance
+
+**User Story:** As a user relying on assistive technology, I want accessible table navigation on mobile, so that I can access table content without losing context.
+
+#### Acceptance Criteria
+
+1. THE Scroll_Container SHALL preserve table semantic structure (thead, tbody, tr, td) for screen readers
+2. THE Card_Layout SHALL use proper ARIA roles where semantic table structure is transformed
+3. THE Mobile_Table_Styles SHALL respect `prefers-reduced-motion` settings
+
+### Requirement 7: Performance
+
+**User Story:** As a site maintainer, I want responsive tables to have minimal performance impact, so that page load times remain fast on mobile.
+
+#### Acceptance Criteria
+
+1. THE Responsive_Behavior SHALL be implemented using CSS only (no JavaScript required for core functionality)
+2. THE CSS_Media_Queries SHALL use existing breakpoint variables to avoid redundant parsing
+
+## Implementation Notes
+
+The suggested approach adds `@media` rules in custom.css for stacked table cells. Two patterns are recommended:
+
+1. **Horizontal scroll (default):** Wrap tables in `.table-responsive` container with `overflow-x: auto`
+2. **Card stack (optional):** Use `display: block` on rows with `::before` for header labels
+
+Verification: Tables in the gas-and-resources document scroll horizontally or stack into cards on mobile viewports below 768px.

--- a/.kiro/specs/mobile-responsive-tables/tasks.md
+++ b/.kiro/specs/mobile-responsive-tables/tasks.md
@@ -1,0 +1,128 @@
+# Implementation Plan: mobile-responsive-tables
+
+## Overview
+
+CSS-only responsive table implementation with two modes: horizontal scroll (default) and stacked card layout (optional). Uses existing Infima CSS tokens for theme consistency. Testing focuses on visual regression and property validation across breakpoints.
+
+## Tasks
+
+- [ ] 1. Set up testing infrastructure for CSS responsive behavior
+  - Identify existing test framework (Vitest/Jest) in the project
+  - Configure visual regression testing (Playwright or similar)
+  - Set up CSS linting (Stylelint) with responsive rules
+  - _Requirements: 7.1, 7.2_
+
+- [ ] 2. Implement horizontal scroll container (.table-responsive)
+  - [ ] 2.1 Create `.table-responsive` CSS class in custom.css
+    - Add `overflow-x: auto` for viewports <768px
+    - Add scroll indicator (box-shadow on right edge)
+    - Use existing `--ifm-table-*` tokens for consistency
+    - _Requirements: 1.1, 1.2, 1.4_
+
+  - [ ] 2.2 Add desktop breakpoint override
+    - Ensure `.table-responsive` has no overflow styles at ≥768px
+    - Use `@media (min-width: 768px)` for desktop-first approach
+    - _Requirements: 1.3_
+
+  - [ ]* 2.3 Write property test for scroll container visibility
+    - **Property 1: Horizontal scroll container visibility**
+    - **Validates: Requirements 1.1, 1.2, 1.4**
+
+  - [ ]* 2.4 Write property test for desktop hiding
+    - **Property 2: Scroll container hidden on desktop**
+    - **Validates: Requirement 1.3**
+
+- [ ] 3. Implement stacked card layout (.table-stacked)
+  - [ ] 3.1 Create `.table-stacked` CSS class for card transformation
+    - Transform `tr` to `display: block` with border on mobile
+    - Transform `td`/`th` to `display: block` with proper padding
+    - Add card-style backgrounds and borders
+    - _Requirements: 2.1, 2.4_
+
+  - [ ] 3.2 Add header-derived cell labels via CSS ::before
+    - Use CSS `content` attr() to pull header labels
+    - Fallback to column index if header unavailable
+    - _Requirements: 2.2_
+
+  - [ ] 3.3 Add mobile breakpoint isolation
+    - Ensure card styles only apply below 768px
+    - Use `@media (max-width: 767px)` for mobile-specific styles
+    - _Requirements: 2.3_
+
+  - [ ]* 3.4 Write property test for card layout cell labeling
+    - **Property 3: Card layout cell labeling**
+    - **Validates: Requirement 2.2**
+
+  - [ ]* 3.5 Write property test for breakpoint isolation
+    - **Property 4: Card layout breakpoint isolation**
+    - **Validates: Requirement 2.3**
+
+- [ ] 4. Add theme support (light/dark mode)
+  - [ ] 4.1 Verify CSS uses existing `--ifm-table-*` tokens
+    - Use `--ifm-table-border-color` for borders
+    - Use `--ifm-table-head-background` for headers
+    - Use `--ifm-table-stripe-background` for row stripes
+    - _Requirements: 4.1, 4.2_
+
+  - [ ] 4.2 Add theme-aware scroll indicator
+    - Use `box-shadow` that adapts via CSS custom properties
+    - Light mode: `rgba(0, 0, 0, 0.1)`
+    - Dark mode: `rgba(0, 0, 0, 0.3)`
+    - _Requirements: 4.3_
+
+  - [ ]* 4.3 Write property test for theme consistency
+    - **Property 5: Theme consistency**
+    - **Validates: Requirements 4.1, 4.2, 4.3**
+
+- [ ] 5. Add accessibility support
+  - [ ] 5.1 Ensure semantic structure preservation
+    - Keep table elements (thead, tbody, tr, td, th) intact
+    - No JavaScript DOM manipulation
+    - _Requirements: 6.1_
+
+  - [ ] 5.2 Add reduced motion support
+    - Wrap scroll/transition effects in `@media (prefers-reduced-motion: no-preference)`
+    - Disable animations when `prefers-reduced-motion: reduce` is set
+    - _Requirements: 6.3_
+
+  - [ ]* 5.3 Write property test for semantic structure
+    - **Property 6: Semantic structure preservation**
+    - **Validates: Requirement 6.1**
+
+  - [ ]* 5.4 Write property test for reduced motion
+    - **Property 7: Reduced motion respect**
+    - **Validates: Requirement 6.3**
+
+- [ ] 6. Checkpoint - Verify all CSS syntax is valid
+  - Run CSS linter on modified files
+  - Ensure no breaking changes to existing table styles
+
+- [ ] 7. Test on gas-and-resources document
+  - [ ] 7.1 Apply `.table-responsive` class to tables in gas-and-resources.md
+    - Identify table elements in the document
+    - Add responsive wrapper classes
+    - _Requirements: 5.1, 5.2_
+
+  - [ ] 7.2 Verify mobile responsiveness
+    - Test horizontal scroll on viewport <768px
+    - Verify scroll indicator appears when needed
+    - _Requirements: 5.1, 5.2_
+
+- [ ]* 8. Write CSS-only implementation property test
+  - **Property 8: CSS-only implementation**
+  - **Validates: Requirements 7.1, 7.2**
+  - Verify no JavaScript is required for core functionality
+
+- [ ] 9. Final checkpoint - Full verification
+  - Ensure all tests pass
+  - Verify responsive behavior on mobile viewport
+  - Verify desktop view remains unaffected
+  - Ask the user if questions arise
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- This is a CSS-only implementation - no JavaScript required
+- Uses existing Infima tokens (`--breakpoint-md`, `--ifm-table-*`) for theme consistency
+- Desktop-first architecture with mobile overrides at <768px
+- Property tests validate universal correctness across all viewport widths


### PR DESCRIPTION
Closes #191

---

- requirements.md: 7 requirements for responsive tables
- design.md: 8 correctness properties with testing strategy
- tasks.md: Implementation plan with 9 tasks

# Pull Request Template

## Description
Provide a clear description of the changes you've made. Explain why you're proposing these changes and link to any relevant issues.

## Type of Change
Select the appropriate type of change:
- [ ] 🚀 New Feature (contracts, patterns, guides)
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 UI/UX Improvement
- [ ] 🛠️ Maintenance / Refactor

## How Has This Been Tested?
Explain how you verified your changes. Include any relevant commands or environment details.
- [ ] Locally rendered using `bun start` (or `npm start`)
- [ ] Ran `bun run build` (or `npm run build`) successfully
- [ ] Verified [typecheck/lint/format] in `documentation/`
- [ ] [If code] Ran `cargo test` and `cargo check`

## Screenshots (if applicable)
Add any screenshots or recordings of UI changes here.

## Checklist
Before submitting, please ensure you've checked these off:
- [ ] My code follows the project's code style.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation accordingly.
- [ ] My changes generate no new warnings.
- [ ] New and existing tests pass locally.
- [ ] I have checked my code runs on the latest Soroban SDK.

## Accessibility (a11y) Checklist
If your changes include new or modified UI components, please verify the following:
- [ ] **Keyboard Navigation:** All interactive elements can be reached and activated using only the keyboard (`Tab`, `Enter`, `Space`).
- [ ] **Focus States:** Focus indicators are clearly visible and consistent across components.
- [ ] **Color Contrast:** Text and background colors meet WCAG 2.1 AA contrast requirements (at least 4.5:1 for normal text).
- [ ] **ARIA & Semantics:** Proper HTML semantics are used, and `aria-*` attributes are added where necessary for screen readers.

---

**Thank you for your contribution! 🚀**
