### PR TITLE
Feat/phase 6 cross browser testing

### DIFF
--- a/.github/workflows/cross-browser.yml
+++ b/.github/workflows/cross-browser.yml
@@ -1,0 +1,92 @@
+name: Cross-Browser E2E Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+concurrency:
+  group: cross-browser-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: E2E – ${{ matrix.browser }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false          # let all browsers finish even if one fails
+      matrix:
+        browser: [chromium, firefox, webkit]
+
+    defaults:
+      run:
+        working-directory: ./documentation
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "1.2.0"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ hashFiles('documentation/bun.lock') }}
+          restore-keys: |
+            bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browsers + OS deps
+        run: npx playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Build documentation
+        run: bun run build
+
+      - name: Serve built site in background
+        run: |
+          bun run serve --port 3000 &
+          # Wait until the server responds before running tests
+          npx wait-on http://localhost:3000 --timeout 60000
+
+      - name: Run smoke tests (${{ matrix.browser }})
+        run: npx playwright test --project=${{ matrix.browser }}
+        env:
+          BASE_URL: http://localhost:3000
+          CI: "true"
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.browser }}
+          path: documentation/playwright-report
+          retention-days: 7
+
+  e2e-summary:
+    name: E2E Summary
+    runs-on: ubuntu-latest
+    needs: e2e
+    if: always()
+    steps:
+      - name: Check all browsers passed
+        run: |
+          if [ "${{ needs.e2e.result }}" != "success" ]; then
+            echo "❌ Cross-browser E2E tests failed"
+            exit 1
+          fi
+          echo "✅ All browsers (chromium, firefox, webkit) passed smoke tests"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -168,6 +168,89 @@ Currently, no environment variables are required for deployment. The workflow us
 - No secrets required for GitHub Pages deployment
 - All code is built from the repository source
 
+## Redirect Management
+
+### Overview
+
+301 client-side redirects are configured via `@docusaurus/plugin-client-redirects` in `documentation/docusaurus.config.ts`. This preserves bookmarks and external links whenever a doc is renamed or relocated.
+
+The plugin generates static HTML redirect pages at build time, so each redirect is a real file that browsers resolve before any JavaScript runs.
+
+### How It Works
+
+Docusaurus builds a lightweight HTML file at every `from` path. Each file contains a `<meta http-equiv="refresh">` redirect and a canonical `<link>` pointing to the `to` destination. This is functionally equivalent to a 301 at the hosting level.
+
+### Adding a New Redirect
+
+When a doc is renamed or moved:
+
+1. Open `documentation/docusaurus.config.ts`.
+2. Locate the `@docusaurus/plugin-client-redirects` entry in the `plugins` array.
+3. Add an object to the `redirects` array:
+
+```ts
+{
+  from: '/docs/old-path',   // the URL that no longer exists
+  to: '/docs/new-path',     // the current canonical URL
+},
+```
+
+4. Commit the change. The redirect is live on the next deployment.
+
+> **Rules:**
+> - `from` must be an **old** path that no longer has a doc at that location.  
+>   Adding a redirect for a path that still resolves to a real page will cause a build error.
+> - Both `from` and `to` must start with `/`.
+> - One `from` can map to exactly one `to`. For multiple old paths pointing to the same page, add multiple objects.
+
+### Current Redirect Map
+
+| Old path | New path | Reason |
+|---|---|---|
+| `/docs/intro` | `/docs/concepts/introduction` | Renamed from scaffold default |
+| `/docs/setup` | `/docs/getting-started/setup` | Moved into Getting Started section |
+| `/docs/getting-started/installation` | `/docs/getting-started/setup` | Unified setup page |
+| `/docs/getting-started/setup-macos` | `/docs/getting-started/setup` | Unified setup page |
+| `/docs/first-contract` | `/docs/getting-started/first-contract` | Moved into Getting Started section |
+| `/docs/getting-started/build` | `/docs/getting-started/building-and-compilation` | Renamed for clarity |
+| `/docs/getting-started/deploy` | `/docs/getting-started/deploy-testnet` | Split into testnet/mainnet pages |
+| `/docs/getting-started/interaction` | `/docs/getting-started/contract-interaction` | Renamed for clarity |
+| `/docs/concepts` | `/docs/concepts/introduction` | Index path now has dedicated page |
+| `/docs/concepts/intro` | `/docs/concepts/introduction` | Renamed |
+| `/docs/concepts/gas` | `/docs/concepts/gas-and-resources` | Renamed for clarity |
+| `/docs/concepts/cross-contract` | `/docs/concepts/cross-contract-invocation` | Renamed for clarity |
+| `/docs/patterns` | `/docs/patterns/overview` | Index path now has dedicated page |
+| `/docs/patterns/types` | `/docs/patterns/custom-types` | Renamed |
+| `/docs/patterns/auth` | `/docs/patterns/authorization` | Renamed |
+| `/docs/patterns/upgrades` | `/docs/patterns/lifecycle-upgrades` | Renamed |
+| `/docs/patterns/optimization` | `/docs/patterns/optimization-playbook` | Renamed |
+| `/docs/contributing/guide` | `/docs/contributing` | Consolidated |
+| `/docs/contributing/tested-example` | `/docs/contributing/add-tested-example` | Renamed |
+| `/docs/tutorial-basics/create-a-document` | `/docs/getting-started/first-contract` | Legacy scaffold path |
+| `/docs/tutorial-basics/deploy-your-site` | `/docs/getting-started/deploy-testnet` | Legacy scaffold path |
+
+### Verifying Redirects Locally
+
+After adding a redirect, build and serve the site locally to confirm:
+
+```bash
+cd documentation
+bun run build
+bun run serve
+```
+
+Then open `http://localhost:3000/docs/<old-path>` in a browser — you should land on the new page. Check the browser's Network tab to confirm the redirect fires.
+
+### Hosting-Level Redirects (Advanced)
+
+If you need true HTTP 301 responses (e.g., for SEO crawlers that don't execute JavaScript), add matching rules at the hosting layer:
+
+**GitHub Pages** does not support server-side redirects natively. The client-redirects plugin is the recommended approach for this deployment target.
+
+**Custom hosting (Nginx / Caddy / Cloudflare Pages):** Add server-level rules that match the `from` paths. Keep them in sync with the plugin config so there is a single source of truth in the repository.
+
+---
+
 ## Future Improvements
 
 - [ ] Add build caching to speed up deployments

--- a/documentation/.gitignore
+++ b/documentation/.gitignore
@@ -18,3 +18,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Playwright
+/playwright-report
+/test-results

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -133,6 +133,107 @@ const config: Config = {
         indexBlog: false,
       },
     ],
+    // ─── 301 Redirects ────────────────────────────────────────────────────────
+    // Maps old/removed paths → current canonical paths so bookmarks and
+    // external links continue to resolve after pages are renamed or moved.
+    // Add new entries here whenever a doc is renamed or relocated.
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          // website/ → documentation/ directory rename (legacy root paths)
+          {
+            from: '/docs/intro',
+            to: '/docs/concepts/introduction',
+          },
+          // Getting Started renames
+          {
+            from: '/docs/setup',
+            to: '/docs/getting-started/setup',
+          },
+          {
+            from: '/docs/getting-started/installation',
+            to: '/docs/getting-started/setup',
+          },
+          {
+            from: '/docs/getting-started/setup-macos',
+            to: '/docs/getting-started/setup',
+          },
+          {
+            from: '/docs/first-contract',
+            to: '/docs/getting-started/first-contract',
+          },
+          {
+            from: '/docs/getting-started/build',
+            to: '/docs/getting-started/building-and-compilation',
+          },
+          {
+            from: '/docs/getting-started/deploy',
+            to: '/docs/getting-started/deploy-testnet',
+          },
+          {
+            from: '/docs/getting-started/interaction',
+            to: '/docs/getting-started/contract-interaction',
+          },
+          // Concepts renames
+          {
+            from: '/docs/concepts',
+            to: '/docs/concepts/introduction',
+          },
+          {
+            from: '/docs/concepts/intro',
+            to: '/docs/concepts/introduction',
+          },
+          {
+            from: '/docs/concepts/gas',
+            to: '/docs/concepts/gas-and-resources',
+          },
+          {
+            from: '/docs/concepts/cross-contract',
+            to: '/docs/concepts/cross-contract-invocation',
+          },
+          // Patterns renames
+          {
+            from: '/docs/patterns',
+            to: '/docs/patterns/overview',
+          },
+          {
+            from: '/docs/patterns/types',
+            to: '/docs/patterns/custom-types',
+          },
+          {
+            from: '/docs/patterns/auth',
+            to: '/docs/patterns/authorization',
+          },
+          {
+            from: '/docs/patterns/upgrades',
+            to: '/docs/patterns/lifecycle-upgrades',
+          },
+          {
+            from: '/docs/patterns/optimization',
+            to: '/docs/patterns/optimization-playbook',
+          },
+          // Contributing renames
+          {
+            from: '/docs/contributing/guide',
+            to: '/docs/contributing',
+          },
+          {
+            from: '/docs/contributing/tested-example',
+            to: '/docs/contributing/add-tested-example',
+          },
+          // Legacy tutorial paths from initial Docusaurus scaffold
+          {
+            from: '/docs/tutorial-basics/create-a-document',
+            to: '/docs/getting-started/first-contract',
+          },
+          {
+            from: '/docs/tutorial-basics/deploy-your-site',
+            to: '/docs/getting-started/deploy-testnet',
+          },
+        ],
+      },
+    ],
   ],
 
   presets: [

--- a/documentation/e2e/smoke.spec.ts
+++ b/documentation/e2e/smoke.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Cross-browser smoke tests for the Soroban Cookbook.
+ *
+ * These tests verify that critical pages load and render core content across
+ * Chromium, Firefox, and WebKit. They run against the built static site
+ * (`bun run build && bun run serve`).
+ */
+
+test.describe('Homepage', () => {
+  test('loads and renders the site title', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle(/Soroban Cookbook/i);
+  });
+
+  test('navbar is visible', async ({ page }) => {
+    await page.goto('/');
+    const navbar = page.getByRole('navigation');
+    await expect(navbar).toBeVisible();
+  });
+
+  test('Docs nav link is present', async ({ page }) => {
+    await page.goto('/');
+    const docsLink = page.getByRole('link', { name: /docs/i }).first();
+    await expect(docsLink).toBeVisible();
+  });
+});
+
+test.describe('Docs – Getting Started', () => {
+  test('setup page loads', async ({ page }) => {
+    await page.goto('/docs/getting-started/setup');
+    await expect(page.getByRole('main')).toBeVisible();
+    await expect(page).toHaveTitle(/setup/i);
+  });
+
+  test('first contract page loads', async ({ page }) => {
+    await page.goto('/docs/getting-started/first-contract');
+    await expect(page.getByRole('main')).toBeVisible();
+  });
+});
+
+test.describe('Docs – Core Concepts', () => {
+  test('introduction page loads', async ({ page }) => {
+    await page.goto('/docs/concepts/introduction');
+    await expect(page.getByRole('main')).toBeVisible();
+  });
+});
+
+test.describe('Redirects', () => {
+  test('/docs/intro redirects to /docs/concepts/introduction', async ({ page }) => {
+    await page.goto('/docs/intro');
+    await expect(page).toHaveURL(/\/docs\/concepts\/introduction/);
+  });
+
+  test('/docs/setup redirects to /docs/getting-started/setup', async ({ page }) => {
+    await page.goto('/docs/setup');
+    await expect(page).toHaveURL(/\/docs\/getting-started\/setup/);
+  });
+});
+
+test.describe('Accessibility – basic', () => {
+  test('homepage has exactly one <h1>', async ({ page }) => {
+    await page.goto('/');
+    const h1s = page.locator('h1');
+    await expect(h1s).toHaveCount(1);
+  });
+
+  test('all images on homepage have alt text', async ({ page }) => {
+    await page.goto('/');
+    const images = page.locator('img');
+    const count = await images.count();
+    for (let i = 0; i < count; i++) {
+      const alt = await images.nth(i).getAttribute('alt');
+      expect(alt, `Image at index ${i} is missing alt text`).not.toBeNull();
+    }
+  });
+});

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -17,7 +17,12 @@
     "lint:fix": "eslint src --ext .ts,.tsx --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,json,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css,json,md}\"",
-    "format:write": "prettier --write \"src/**/*.{ts,tsx,css,json,md}\""
+    "format:write": "prettier --write \"src/**/*.{ts,tsx,css,json,md}\"",
+    "e2e": "playwright test",
+    "e2e:chromium": "playwright test --project=chromium",
+    "e2e:firefox": "playwright test --project=firefox",
+    "e2e:webkit": "playwright test --project=webkit",
+    "e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",
@@ -48,7 +53,8 @@
     "globals": "^15.0.0",
     "prettier": "^3.8.1",
     "sharp": "^0.34.5",
-    "typescript": "~5.6.2"
+    "@playwright/test": "1.49.1",
+    "wait-on": "8.0.2"
   },
   "browserslist": {
     "production": [

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",
+    "@docusaurus/plugin-client-redirects": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
     "@easyops-cn/docusaurus-search-local": "0.49.2",
     "@fontsource-variable/inter": "^5.2.8",

--- a/documentation/playwright.config.ts
+++ b/documentation/playwright.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Cross-browser smoke-test configuration.
+ *
+ * Targets: Chromium (Chrome/Edge), Firefox, WebKit (Safari).
+ * Tests live in documentation/e2e/ and run against the pre-built static site
+ * served by `docusaurus serve` on port 3000.
+ *
+ * Usage:
+ *   bun run build && bun run e2e              # all browsers
+ *   bun run e2e:chromium                      # single browser
+ */
+export default defineConfig({
+  testDir: './e2e',
+  /* Maximum time one test can run */
+  timeout: 30_000,
+  /* Fail the run as soon as one test fails in CI */
+  forbidOnly: !!process.env.CI,
+  /* No retries locally; 1 retry in CI to absorb flakiness */
+  retries: process.env.CI ? 1 : 0,
+  /* Parallelise across workers */
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never', outputFolder: 'playwright-report' }]]
+    : [['list'], ['html', { open: 'on-failure', outputFolder: 'playwright-report' }]],
+
+  use: {
+    /* Base URL – served by `bun run serve` or the CI serve step */
+    baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
+    /* Capture trace on first retry to aid debugging */
+    trace: 'on-first-retry',
+    /* Screenshots only on failure */
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+});


### PR DESCRIPTION
escription

Sets up Playwright for cross-browser smoke testing across Chromium (Chrome/Edge), Firefox, and WebKit (Safari), with a CI matrix that runs all three in parallel.

Changes

cross-browser.yml
 — New workflow with a matrix: browser: [chromium, firefox, webkit] strategy. Each browser job: installs Playwright with OS deps, builds the site, serves it on port 3000 (using wait-on to gate the tests until the server is ready), runs the smoke suite, and uploads the Playwright HTML report as an artifact. fail-fast: false ensures all browsers complete even if one fails. A summary job gates the overall result.

playwright.config.ts
 — Playwright config targeting e2e/ tests. Configures three projects (chromium, firefox, webkit) using @playwright/test device descriptors. Sets baseURL from BASE_URL env var (defaults to localhost:3000), 1 retry in CI, trace: on-first-retry, and screenshot: only-on-failure.

smoke.spec.ts
 — Smoke test suite covering: homepage title and navbar, Docs nav link, Getting Started pages (setup, first-contract), Core Concepts intro page, redirect assertions (verifying #187 redirects fire correctly), and basic accessibility checks (single <h1>, all images have alt text).

package.json
 — Added @playwright/test@1.49.1 and wait-on@8.0.2 to devDependencies; added e2e, e2e:chromium, e2e:firefox, e2e:webkit, and e2e:report scripts.

.gitignore
 — Added /playwright-report and /test-results.
 
 cd documentation
bun install
bun run build
bun run serve &
bun run e2e           # all three browsers
bun run e2e:chromium  # single browser

Verification steps

All three browser projects pass the smoke tests. Each old path tested in the redirect suite resolves to the correct canonical URL.

closes #188 
