### PR TITLE
feat: configure alert system for CI failures and uptime monitoring

### DIFF
--- a/.github/workflows/alerts.yml
+++ b/.github/workflows/alerts.yml
@@ -1,0 +1,227 @@
+name: Alert System
+
+on:
+  # Fire after every CI run on main so failures are caught immediately
+  workflow_run:
+    workflows:
+      - CI
+      - "CD - Deploy to GitHub Pages"
+    types:
+      - completed
+    branches:
+      - main
+
+  # Uptime probe: runs on a schedule independent of code pushes
+  schedule:
+    # Every 30 minutes, 24 × 7
+    - cron: '*/30 * * * *'
+
+  # Allow manual test-fire from the Actions tab
+  workflow_dispatch:
+    inputs:
+      test_alert:
+        description: 'Send a test alert to verify the integration'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+jobs:
+  # ─── CI / CD failure alerts ────────────────────────────────────────────────
+  notify-failure:
+    name: Notify on CI/CD failure
+    runs-on: ubuntu-latest
+    # Only run when triggered by a workflow_run event AND that run failed
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Build Slack failure payload
+        id: payload
+        run: |
+          cat <<'EOF' > payload.json
+          {
+            "text": ":red_circle: *CI/CD failure* on `${{ github.event.workflow_run.head_branch }}`",
+            "attachments": [
+              {
+                "color": "#FF0000",
+                "fields": [
+                  {
+                    "title": "Workflow",
+                    "value": "${{ github.event.workflow_run.name }}",
+                    "short": true
+                  },
+                  {
+                    "title": "Branch",
+                    "value": "${{ github.event.workflow_run.head_branch }}",
+                    "short": true
+                  },
+                  {
+                    "title": "Triggered by",
+                    "value": "${{ github.event.workflow_run.triggering_actor.login }}",
+                    "short": true
+                  },
+                  {
+                    "title": "Commit",
+                    "value": "${{ github.event.workflow_run.head_sha }}",
+                    "short": true
+                  },
+                  {
+                    "title": "Run URL",
+                    "value": "${{ github.event.workflow_run.html_url }}"
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+
+      - name: Send Slack alert
+        # Requires secret: SLACK_WEBHOOK_URL
+        # See DEPLOYMENT.md → Alert System → Setup for instructions
+        if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload-file-path: payload.json
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  notify-recovery:
+    name: Notify on CI/CD recovery
+    runs-on: ubuntu-latest
+    # Only run when triggered by a workflow_run event AND that run succeeded
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Send Slack recovery message
+        if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "text": ":large_green_circle: *CI/CD recovered* — `${{ github.event.workflow_run.name }}` passed on `${{ github.event.workflow_run.head_branch }}`",
+              "attachments": [
+                {
+                  "color": "#36A64F",
+                  "fields": [
+                    {
+                      "title": "Run URL",
+                      "value": "${{ github.event.workflow_run.html_url }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  # ─── Uptime probe ──────────────────────────────────────────────────────────
+  uptime-check:
+    name: Uptime probe
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    outputs:
+      site_up: ${{ steps.probe.outputs.site_up }}
+      status_code: ${{ steps.probe.outputs.status_code }}
+    steps:
+      - name: Probe site
+        id: probe
+        run: |
+          SITE_URL="${{ vars.SITE_URL || 'https://soroban-cookbook.dev' }}"
+          HTTP_CODE=$(curl -o /dev/null -s -w "%{http_code}" \
+            --max-time 15 \
+            --retry 3 \
+            --retry-delay 5 \
+            "$SITE_URL")
+
+          echo "status_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+
+          if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 400 ]; then
+            echo "site_up=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Site is UP — HTTP $HTTP_CODE"
+          else
+            echo "site_up=false" >> "$GITHUB_OUTPUT"
+            echo "❌ Site is DOWN — HTTP $HTTP_CODE"
+            exit 1
+          fi
+
+      - name: Alert on downtime
+        if: failure() && ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "text": ":rotating_light: *Site DOWN* — ${{ vars.SITE_URL || 'https://soroban-cookbook.dev' }} returned HTTP `${{ steps.probe.outputs.status_code }}`",
+              "attachments": [
+                {
+                  "color": "#FF0000",
+                  "fields": [
+                    {
+                      "title": "URL",
+                      "value": "${{ vars.SITE_URL || 'https://soroban-cookbook.dev' }}",
+                      "short": true
+                    },
+                    {
+                      "title": "HTTP status",
+                      "value": "${{ steps.probe.outputs.status_code }}",
+                      "short": true
+                    },
+                    {
+                      "title": "Check run",
+                      "value": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  # ─── Manual test alert ─────────────────────────────────────────────────────
+  test-alert:
+    name: Send test alert
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.test_alert == 'true'
+    steps:
+      - name: Send test Slack message
+        if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "text": ":white_check_mark: *Test alert* — Soroban Cookbook alert system is configured correctly.",
+              "attachments": [
+                {
+                  "color": "#36A64F",
+                  "fields": [
+                    {
+                      "title": "Triggered by",
+                      "value": "${{ github.actor }}",
+                      "short": true
+                    },
+                    {
+                      "title": "Repository",
+                      "value": "${{ github.repository }}",
+                      "short": true
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+      - name: Confirm (no webhook configured)
+        if: ${{ secrets.SLACK_WEBHOOK_URL == '' }}
+        run: |
+          echo "⚠️  SLACK_WEBHOOK_URL secret is not set."
+          echo "Add it under Settings → Secrets → Actions and re-run this workflow."
+          exit 1

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -168,6 +168,66 @@ Currently, no environment variables are required for deployment. The workflow us
 - No secrets required for GitHub Pages deployment
 - All code is built from the repository source
 
+## Alert System
+
+Alerting is handled by `.github/workflows/alerts.yml`. The workflow covers three scenarios:
+
+| Trigger | Job | What fires |
+|---|---|---|
+| CI or CD workflow fails on `main` | `notify-failure` | Slack message with workflow name, branch, commit, actor, and run URL |
+| CI or CD workflow recovers on `main` | `notify-recovery` | Slack recovery message |
+| Schedule (every 30 min) | `uptime-check` | HTTP probe against the live site; Slack alert if non-2xx/3xx |
+| Manual `workflow_dispatch` with `test_alert=true` | `test-alert` | Sends a test Slack message to verify the integration |
+
+### Setup
+
+#### 1. Create a Slack Incoming Webhook
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From scratch**.
+2. Name it `Soroban Cookbook Alerts`, pick your workspace.
+3. Under **Features** → **Incoming Webhooks**, toggle **Activate Incoming Webhooks** on.
+4. Click **Add New Webhook to Workspace**, select the target channel (e.g. `#soroban-alerts`), and click **Allow**.
+5. Copy the webhook URL (format: `https://hooks.slack.com/services/…`).
+
+#### 2. Add the secret to GitHub
+
+1. Go to **Settings → Secrets and variables → Actions**.
+2. Click **New repository secret**.
+3. Name: `SLACK_WEBHOOK_URL` — Value: the URL copied above.
+
+#### 3. (Optional) Override the monitored URL
+
+The uptime probe defaults to `https://soroban-cookbook.dev`. To change it without editing the workflow:
+
+1. Go to **Settings → Secrets and variables → Actions → Variables** tab.
+2. Add a variable named `SITE_URL` with the target URL as the value.
+
+#### 4. Verify the integration
+
+1. Go to **Actions** → **Alert System** → **Run workflow**.
+2. Set **test_alert** to `true` and click **Run workflow**.
+3. A test message should appear in your Slack channel within seconds.
+
+### On-Call Rotation
+
+This project is community-maintained. There is no formal PagerDuty rotation. The Slack channel configured above serves as the incident notification channel. Triage follows this process:
+
+1. **Slack alert fires** → anyone with repository access investigates the linked Actions run.
+2. **Build failure** → check the failed job logs; common causes are dependency updates or broken Rust examples.
+3. **Site downtime** → check GitHub Pages status at [githubstatus.com](https://www.githubstatus.com) first. If Pages is healthy, check the last deployment run.
+4. **Escalation** → open a GitHub issue tagged `incident` and post in [Stellar Discord](https://discord.gg/stellardev) `#soroban-dev`.
+
+If you want to set up a formal PagerDuty integration, replace the `slackapi/slack-github-action` steps with calls to the [PagerDuty Events API v2](https://developer.pagerduty.com/api-reference/YXBpOjI3NDgyNjU-pager-duty-v2-events-api) using a `PAGERDUTY_INTEGRATION_KEY` secret.
+
+### Alert Channels Reference
+
+| Channel | Purpose | Configured via |
+|---|---|---|
+| Slack `#soroban-alerts` | CI failures, recoveries, downtime | `SLACK_WEBHOOK_URL` secret |
+| GitHub Actions email | Default GitHub notification for workflow failures | GitHub account notification settings |
+
+---
+
 ## Future Improvements
 
 - [ ] Add build caching to speed up deployments


### PR DESCRIPTION
Wires CI/CD failure alerts and uptime monitoring to Slack, with a manual test-fire trigger and full setup documentation. No third-party services are hard-coded — everything is opt-in via repository secrets/variables.
Changes

alerts.yml
 — New workflow with four jobs:

Job	Trigger	What it does
notify-failure	CI or CD workflow fails on main	Posts a Slack message with workflow name, branch, actor, commit SHA, and direct run URL
notify-recovery	CI or CD workflow recovers on main	Posts a green recovery message to the same channel
uptime-check	Cron every 30 min	curl probe against the live site (configurable via SITE_URL variable); fires a Slack downtime alert on non-2xx/3xx response
test-alert	Manual workflow_dispatch with test_alert=true	Sends a test message to verify the webhook is wired correctly
All Slack steps are gated on SLACK_WEBHOOK_URL being set, so the workflow is safe to merge before the secret exists — jobs simply skip rather than error.

DEPLOYMENT.md — Added Alert System section covering: setup steps (create Slack app → add webhook → add GitHub secret → optional SITE_URL override → test-fire), an on-call triage process for the community project, a note on swapping to PagerDuty, and an alert channels reference table.

Required secret

Name	Where	Value
SLACK_WEBHOOK_URL	Settings → Secrets → Actions	Slack Incoming Webhook URL
Optional variable

Name	Default	Purpose
SITE_URL	https://soroban-cookbook.dev	URL probed by the uptime check

Verification

Run the workflow manually from Actions → Alert System → Run workflow with test_alert = true. A test message will appear in the configured Slack channel.

closes #189