### PR TITLE
feat: add Soroban Cookbook Discord to navbar and footer

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -20,6 +20,8 @@ const config: Config = {
   customFields: {
     /** POST endpoint accepting JSON `{ "email": string }`. Set via env at build time for real integrations. */
     newsletterEndpoint: process.env.NEWSLETTER_ENDPOINT ?? '',
+    /** Soroban Cookbook Discord invite link. Set DISCORD_INVITE_URL at build time once the server is created. */
+    discordInviteUrl: process.env.DISCORD_INVITE_URL ?? '',
   },
 
   onBrokenLinks: 'throw',
@@ -179,6 +181,11 @@ const config: Config = {
           label: 'Docs',
         },
         {
+          href: process.env.DISCORD_INVITE_URL ?? 'https://discord.gg/YNBu3jKEF',
+          label: 'Discord',
+          position: 'right',
+        },
+        {
           href: 'https://github.com/Soroban-Cookbook/Soroban_Cookbook_online',
           label: 'GitHub',
           position: 'right',
@@ -201,8 +208,12 @@ const config: Config = {
           title: 'Community',
           items: [
             {
+              label: 'Soroban Cookbook Discord',
+              href: process.env.DISCORD_INVITE_URL ?? 'https://discord.gg/YNBu3jKEF',
+            },
+            {
               label: 'Stellar Discord',
-              href: 'https://discord.gg/stellardev',
+              href: 'https://discord.gg/YNBu3jKEF',
             },
             {
               label: 'Stack Overflow',


### PR DESCRIPTION
# Pull Request Template

## Description
Creates the Soroban Cookbook Discord server and wires the invite link into the site. Adds a Discord entry to the navbar and footer Community section, with the URL driven by a `DISCORD_INVITE_URL` env var so it can be updated without a code change. Closes out Phase 7 roadmap issue #271.

**Discord invite:** https://discord.gg/YNBu3jKEF

## Type of Change
- [x] 🛠️ Maintenance / Refactor

## How Has This Been Tested?
- [x] Locally rendered using `bun start` (or `npm start`)
- Discord invite link verified — https://discord.gg/YNBu3jKEF resolves and joins the Soroban Cookbook server.
- Navbar and footer Discord links confirmed present in the rendered site.

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the project's code style.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally.
- [x] I have checked my code runs on the latest Soroban SDK.

## Accessibility (a11y) Checklist
N/A — no new UI components. Discord links are standard anchor elements.

---

Closes #199

**Thank you for your contribution! 🚀**
