### PR TITLE
Adds an accessible copy button for fenced code blocks in the documentation site, with clear feedback when copy succeeds or fails.

### DIFF
--- a/documentation/e2e/code-block-copy.spec.ts
+++ b/documentation/e2e/code-block-copy.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test';
+
+test('copy button copies the visible code block content', async ({ page }) => {
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.goto('/docs/getting-started/setup');
+
+  const codeBlock = page.locator('pre').filter({has: page.locator('code')}).first();
+  await expect(codeBlock).toBeVisible();
+
+  const expectedText = (await codeBlock.innerText()).trim();
+  const copyButton = page.getByRole('button', { name: /copy code/i }).first();
+
+  await expect(copyButton).toBeVisible();
+  await copyButton.click();
+
+  await expect(copyButton).toHaveText(/copied!/i);
+  await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe(expectedText);
+});

--- a/documentation/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
+++ b/documentation/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
@@ -1,7 +1,7 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
-import {translate} from '@docusaurus/Translate';
-import {useCodeBlockContext} from '@docusaurus/theme-common/internal';
+import { translate } from '@docusaurus/Translate';
+import { useCodeBlockContext } from '@docusaurus/theme-common/internal';
 import Button from '@theme/CodeBlock/Buttons/Button';
 import IconCopy from '@theme/Icon/Copy';
 import IconSuccess from '@theme/Icon/Success';
@@ -73,13 +73,13 @@ function trackCopy(language: string | undefined) {
   }
 
   if (Array.isArray(window.dataLayer)) {
-    window.dataLayer.push({event: 'copy_code_block', ...eventData});
+    window.dataLayer.push({ event: 'copy_code_block', ...eventData });
   }
 }
 
 function useCopyButton() {
   const {
-    metadata: {code, language},
+    metadata: { code, language },
   } = useCodeBlockContext();
   const [copyState, setCopyState] = useState<CopyState>('idle');
   const timeoutRef = useRef<number | null>(null);
@@ -115,17 +115,21 @@ function useCopyButton() {
     };
   }, []);
 
-  return {copyCode, copyState};
+  return { copyCode, copyState };
 }
 
-export default function CopyButton({className}: {className?: string}) {
-  const {copyCode, copyState} = useCopyButton();
+export default function CopyButton({ className }: { className?: string }) {
+  const { copyCode, copyState } = useCopyButton();
 
   return (
     <Button
       aria-label={ariaLabel(copyState)}
       title={title()}
-      className={clsx(className, styles.copyButton, copyState !== 'idle' && styles.copyButtonActive)}
+      className={clsx(
+        className,
+        styles.copyButton,
+        copyState !== 'idle' && styles.copyButtonActive,
+      )}
       onClick={copyCode}>
       <span className={styles.copyButtonIcons} aria-hidden="true">
         <IconCopy className={styles.copyButtonIcon} />

--- a/documentation/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
+++ b/documentation/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
@@ -1,0 +1,139 @@
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {useCodeBlockContext} from '@docusaurus/theme-common/internal';
+import Button from '@theme/CodeBlock/Buttons/Button';
+import IconCopy from '@theme/Icon/Copy';
+import IconSuccess from '@theme/Icon/Success';
+import styles from './styles.module.css';
+
+type CopyState = 'idle' | 'success' | 'error';
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+    dataLayer?: unknown[];
+  }
+}
+
+function title() {
+  return translate({
+    id: 'theme.CodeBlock.copy',
+    message: 'Copy',
+    description: 'The copy button label on code blocks',
+  });
+}
+
+function ariaLabel(state: CopyState) {
+  switch (state) {
+    case 'success':
+      return translate({
+        id: 'theme.CodeBlock.copied',
+        message: 'Copied',
+        description: 'The copied button label on code blocks',
+      });
+    case 'error':
+      return translate({
+        id: 'theme.CodeBlock.copyFailed',
+        message: 'Copy failed',
+        description: 'The copy failed button label on code blocks',
+      });
+    default:
+      return translate({
+        id: 'theme.CodeBlock.copyButtonAriaLabel',
+        message: 'Copy code to clipboard',
+        description: 'The ARIA label for copy code blocks button',
+      });
+  }
+}
+
+function labelFor(state: CopyState) {
+  switch (state) {
+    case 'success':
+      return 'Copied!';
+    case 'error':
+      return 'Failed';
+    default:
+      return 'Copy';
+  }
+}
+
+function trackCopy(language: string | undefined) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const eventData = {
+    event_category: 'CodeBlock',
+    event_label: language ?? 'unknown',
+  };
+
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', 'copy_code_block', eventData);
+  }
+
+  if (Array.isArray(window.dataLayer)) {
+    window.dataLayer.push({event: 'copy_code_block', ...eventData});
+  }
+}
+
+function useCopyButton() {
+  const {
+    metadata: {code, language},
+  } = useCodeBlockContext();
+  const [copyState, setCopyState] = useState<CopyState>('idle');
+  const timeoutRef = useRef<number | null>(null);
+
+  const copyCode = useCallback(async () => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      setCopyState('error');
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopyState('success');
+      trackCopy(language);
+    } catch {
+      setCopyState('error');
+    }
+
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      setCopyState('idle');
+    }, 2000);
+  }, [code, language]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return {copyCode, copyState};
+}
+
+export default function CopyButton({className}: {className?: string}) {
+  const {copyCode, copyState} = useCopyButton();
+
+  return (
+    <Button
+      aria-label={ariaLabel(copyState)}
+      title={title()}
+      className={clsx(className, styles.copyButton, copyState !== 'idle' && styles.copyButtonActive)}
+      onClick={copyCode}>
+      <span className={styles.copyButtonIcons} aria-hidden="true">
+        <IconCopy className={styles.copyButtonIcon} />
+        <IconSuccess className={styles.copyButtonSuccessIcon} />
+      </span>
+      <span className={styles.copyButtonLabel} aria-live="polite">
+        {labelFor(copyState)}
+      </span>
+    </Button>
+  );
+}

--- a/documentation/src/theme/CodeBlock/Buttons/CopyButton/styles.module.css
+++ b/documentation/src/theme/CodeBlock/Buttons/CopyButton/styles.module.css
@@ -10,7 +10,10 @@
   cursor: pointer;
   font-size: 0.75rem;
   line-height: 1;
-  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease;
 }
 
 .copyButton:hover {

--- a/documentation/src/theme/CodeBlock/Buttons/CopyButton/styles.module.css
+++ b/documentation/src/theme/CodeBlock/Buttons/CopyButton/styles.module.css
@@ -1,0 +1,60 @@
+.copyButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.375rem;
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
+  cursor: pointer;
+  font-size: 0.75rem;
+  line-height: 1;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.copyButton:hover {
+  background: var(--ifm-hover-overlay);
+  border-color: var(--ifm-color-primary);
+}
+
+.copyButton:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
+.copyButtonActive {
+  border-color: var(--ifm-color-success);
+  color: var(--ifm-color-success);
+}
+
+.copyButtonIcons {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+}
+
+.copyButtonIcon,
+.copyButtonSuccessIcon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.copyButtonSuccessIcon {
+  display: none;
+}
+
+.copyButtonActive .copyButtonIcon {
+  display: none;
+}
+
+.copyButtonActive .copyButtonSuccessIcon {
+  display: inline-block;
+}
+
+.copyButtonLabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
Adds an accessible copy button for fenced code blocks in the documentation site, with clear feedback when copy succeeds or fails.

## Changes
- Added a shared copy button for Docusaurus code blocks
- Improved button accessibility and labels
- Added regression coverage for the copy interaction

Closes #158