### PR TITLE
feat: add gh-pages pr preview workflow

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,35 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write 
+  pull-requests: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./documentation
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: Build Documentation
+        run: bun run build
+
+      - name: Deploy PR Preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./documentation/dist
+          action: auto

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 permissions:
-  contents: write 
+  contents: write
   pull-requests: write
 
 jobs:
@@ -23,10 +23,10 @@ jobs:
         uses: oven-sh/setup-bun@v1
 
       - name: Install Dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
-      - name: Build Documentation
-        run: bun run build
+      - name: Format, Lint, Typecheck, and Build
+        run: bun run format:check && bun run lint && bun run typecheck && bun run build
 
       - name: Deploy PR Preview
         uses: rossjrw/pr-preview-action@v1


### PR DESCRIPTION
## Description
This PR implements an automated preview deployment workflow for pull requests using GitHub Pages, fulfilling the infrastructure requirements for Phase 7. 

Whenever a PR is opened, updated, or reopened, the workflow triggers a standalone build using Bun within the `./documentation` directory and deploys the production-ready static files to a dedicated staging subdirectory on the `gh-pages` branch. It automatically comments the unique deployment preview URL back onto the PR timeline for instant verification.

Closes #155