### PR TITLE
feat :  add Internal Linking Strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,41 @@ jobs:
       - name: Lint with ESLint
         run: bun run lint
 
+      - name: Audit heading hierarchy
+        run: bun run audit:headings
+
+      - name: Audit internal links
+        run: bun run audit:links
+
+  external-links:
+    name: External Link Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./documentation
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "1.2.0"
+
+      - name: Check external links
+        run: bun run check:external-links
+        env:
+          EXTERNAL_LINK_TIMEOUT_MS: 20000
+          EXTERNAL_LINK_CONCURRENCY: 10
+
+      - name: Upload link audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: external-link-report
+          path: documentation/reports/external-links.md
+          retention-days: 14
+
   typecheck:
     name: TypeScript Check
     runs-on: ubuntu-latest
@@ -250,7 +285,7 @@ jobs:
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [lint-format, typecheck, build-docs, validate-deployment, test-examples, e2e-console]
+    needs: [lint-format, typecheck, build-docs, validate-deployment, test-examples, e2e-console, external-links]
     if: always()
     steps:
       - name: Check job statuses
@@ -277,6 +312,10 @@ jobs:
           fi
           if [ "${{ needs.e2e-console.result }}" != "success" ]; then
             echo "❌ Browser console audit failed"
+            exit 1
+          fi
+          if [ "${{ needs.external-links.result }}" != "success" ]; then
+            echo "❌ External link check failed"
             exit 1
           fi
           echo "✅ All CI checks passed"

--- a/documentation/.gitignore
+++ b/documentation/.gitignore
@@ -24,3 +24,6 @@ yarn-error.log*
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Generated link audit reports
+/reports/

--- a/documentation/docs/components/alert-callout-showcase.mdx
+++ b/documentation/docs/components/alert-callout-showcase.mdx
@@ -7,8 +7,6 @@ description: Complete showcase of alert and callout components
 import { Alert } from '@site/src/components/Alert';
 import { Callout } from '@site/src/components/Callout';
 
-# Alert & Callout Showcase
-
 Complete demonstration of all alert and callout component features.
 
 ## Alert Variants
@@ -272,3 +270,11 @@ Try navigating this page with:
 - **Zoom**: Test at 200% zoom level
 
 All components remain fully functional and accessible.
+
+---
+
+## Related links
+
+- [Alerts Component](/docs/components/alerts) — alert API reference
+- [Callouts Component](/docs/components/callouts) — callout API reference
+- [Alerts & Callouts design tokens](/docs/design-system/alerts-callouts) — styling spec

--- a/documentation/docs/components/alerts.mdx
+++ b/documentation/docs/components/alerts.mdx
@@ -6,8 +6,6 @@ description: Alert components for important messages
 
 import { Alert } from '@site/src/components/Alert';
 
-# Alerts
-
 Display important messages with visual emphasis using the Alert component.
 
 ## Examples
@@ -53,3 +51,10 @@ import { Alert } from '@site/src/components/Alert';
 <Alert variant="warning" title="Warning">Important notice</Alert>
 <Alert variant="error" icon={false}>Error without icon</Alert>
 ```
+
+---
+
+## Related links
+
+- [Alerts & Callouts design tokens](/docs/design-system/alerts-callouts) — visual spec and variants
+- [Alert & Callout Showcase](/docs/components/alert-callout-showcase) — interactive examples

--- a/documentation/docs/components/buttons.mdx
+++ b/documentation/docs/components/buttons.mdx
@@ -1,13 +1,11 @@
 ---
-title: Buttons
+title: Button Component
 description: Soroban Cookbook button system with variants, sizes, states, icon support, and accessibility guidance.
 ---
 
 import React from 'react';
 import Button from '@site/src/components/UI/Button';
 import ButtonGroup from '@site/src/components/UI/Button/ButtonGroup';
-
-# Button Component
 
 This button system includes:
 
@@ -89,3 +87,10 @@ Defined in `src/css/custom.css`:
 - Durations: `--sb-motion-duration-fast`, `--sb-motion-duration-normal`, `--sb-motion-duration-slow`
 - Easing: `--sb-motion-ease-standard`, `--sb-motion-ease-in`, `--sb-motion-ease-out`
 - Utilities: `.sb-transition-none`, `.sb-transition-fast`, `.sb-transition-normal`, `.sb-transition-slow`
+
+---
+
+## Related links
+
+- [Button System](/docs/design-system/buttons) — design tokens and variants
+- [Typography System](/docs/design-system/typography) — type scale for labels

--- a/documentation/docs/components/callouts.mdx
+++ b/documentation/docs/components/callouts.mdx
@@ -6,8 +6,6 @@ description: Callout components for documentation emphasis
 
 import { Callout } from '@site/src/components/Callout';
 
-# Callouts
-
 Specialized alert components for documentation with stronger visual emphasis.
 
 ## Examples
@@ -61,3 +59,10 @@ import { Callout } from '@site/src/components/Callout';
   Important warning message
 </Callout>
 ```
+
+---
+
+## Related links
+
+- [Alerts & Callouts design tokens](/docs/design-system/alerts-callouts) — styling reference
+- [Alerts Component](/docs/components/alerts) — alert variant comparison

--- a/documentation/docs/components/iconography.mdx
+++ b/documentation/docs/components/iconography.mdx
@@ -24,8 +24,6 @@ import {
   Terminal,
 } from "lucide-react";
 
-# Iconography
-
 This guide covers the icon system used in the Soroban Cookbook documentation. We use [Lucide](https://lucide.dev/) as our icon library, chosen for its clean design, consistency, and excellent accessibility support.
 
 ## Installation
@@ -338,3 +336,11 @@ export const IconGrid = ({ icons }) => (
     ))}
   </div>
 );
+
+---
+
+## Related links
+
+- [Typography System](/docs/design-system/typography) — icon sizing alongside type scale
+- [Button Component](/docs/components/buttons) — icons in buttons
+- [Responsive Breakpoints](/docs/responsive/breakpoints) — icon layout at different viewports

--- a/documentation/docs/components/testimonials.mdx
+++ b/documentation/docs/components/testimonials.mdx
@@ -1,12 +1,10 @@
 ---
-title: Testimonials
+title: Testimonials Component
 description: Community testimonials section component with responsive cards and social channels.
 ---
 
 import React from 'react';
 import Testimonials from '@site/src/components/UI/Testimonials';
-
-# Testimonials Component
 
 The `Testimonials` component renders a responsive community section for the homepage with:
 
@@ -92,3 +90,10 @@ type TestimonialsProps = {
 - External links use `target="_blank"` with `rel="noopener noreferrer"`.
 - Community links and profile links include explicit `aria-label` values.
 - Uses semantic `section`, `article`, `header`, and `blockquote` structure.
+
+---
+
+## Related links
+
+- [Empty States](/docs/design-system/empty-states) — layout patterns for sparse content
+- [Button Component](/docs/components/buttons) — CTA buttons in community sections

--- a/documentation/docs/concepts/authorization.md
+++ b/documentation/docs/concepts/authorization.md
@@ -1,4 +1,8 @@
-# Authorization
+---
+title: Authorization
+description: Access control patterns for Soroban smart contracts.
+sidebar_position: 5
+---
 
 Authorization in Soroban ensures only expected identities can execute sensitive contract actions.
 
@@ -24,5 +28,6 @@ Authorization in Soroban ensures only expected identities can execute sensitive 
 ## Next
 
 - [Security Fundamentals](../security/fundamentals.md)
+- [Token Pattern Security Audit](../security/token-audit.md)
 - [Storage Patterns](./storage.md)
 - [Events](./events.md)

--- a/documentation/docs/concepts/best-practices.md
+++ b/documentation/docs/concepts/best-practices.md
@@ -1,4 +1,8 @@
-# Soroban Best Practices
+---
+title: Soroban Best Practices
+description: Practical do/don't rules and checklists for production-ready Soroban contracts.
+sidebar_position: 3
+---
 
 A concise, beginner-friendly guide for new Soroban developers. Use this page to learn practical do/don't rules, common anti-patterns, and a reusable checklist for your first production-ready contract.
 
@@ -171,6 +175,7 @@ A production-ready Soroban contract should pass more than just compilation. Use 
 
 ## Learn more
 
-- [First Contract](../getting-started/first-contract)
-- [Storage Best Practices](./storage)
-- [Authorization Concepts](./authorization)
+- [First Contract](/docs/getting-started/first-contract)
+- [Storage Best Practices](/docs/concepts/storage)
+- [Authorization Concepts](/docs/concepts/authorization)
+- [Security Fundamentals](/docs/security/fundamentals)

--- a/documentation/docs/concepts/cross-contract-invocation.md
+++ b/documentation/docs/concepts/cross-contract-invocation.md
@@ -4,8 +4,6 @@ description: A practical guide to secure and maintainable cross-contract calls i
 sidebar_position: 7
 ---
 
-# Cross-Contract Invocation
-
 Soroban contracts can call functions on other on-chain contracts. This is the mechanism that enables composable applications: a lending protocol can invoke a token contract, a router can delegate to a price oracle, and an aggregator can orchestrate multiple DeFi primitives in a single transaction.
 
 This guide explains how cross-contract calls work, where they can go wrong, and how to write and test them safely.

--- a/documentation/docs/concepts/error-handling.md
+++ b/documentation/docs/concepts/error-handling.md
@@ -1,10 +1,8 @@
 ---
-title: Error Handling
+title: Error Handling in Soroban
 description: Understanding error handling in Soroban smart contracts
 sidebar_position: 5
 ---
-
-# Error Handling in Soroban
 
 ## Overview
 
@@ -243,4 +241,4 @@ Proper error handling is critical for security:
 
 - [Rust Error Handling Book](https://doc.rust-lang.org/book/ch09-00-error-handling.html)
 - [Soroban SDK Documentation](https://docs.rs/soroban-sdk/)
-- [Stellar Developer Portal](https://developers.stellar.org/docs/smart-contracts)
+- [Stellar Developer Portal](https://developers.stellar.org/docs/build/smart-contracts)

--- a/documentation/docs/concepts/events.md
+++ b/documentation/docs/concepts/events.md
@@ -1,4 +1,8 @@
-# Events
+---
+title: Events
+description: Emitting and consuming events for observability and off-chain indexing.
+sidebar_position: 6
+---
 
 Events provide a reliable audit trail of what happened in your contract and help indexers and UIs react to on-chain activity.
 

--- a/documentation/docs/concepts/gas-and-resources.md
+++ b/documentation/docs/concepts/gas-and-resources.md
@@ -4,8 +4,6 @@ title: Gas and Resource Management
 description: Document resource usage fundamentals and optimization strategies in Soroban.
 ---
 
-# Gas and Resource Management
-
 In Soroban, smart contracts execute within resource budgets to ensure the network remains efficient and fair for all users. Managing gas and resources is a critical part of developing cost-effective and scalable smart contracts. 
 
 This guide outlines how to identify high-cost operations, strategies to optimize resource consumption, and practical methods for monitoring contract performance.
@@ -115,3 +113,11 @@ To ensure your contracts remain within budget and are cost-effective, continuous
 
 3. **Monitor the Network Limits:**
    Keep an eye on the Stellar network's global parameters. If network usage spikes, the cost per instruction or ledger byte can increase. Design your contracts to comfortably fit within baseline limits to avoid out-of-gas errors during high-traffic periods.
+
+---
+
+## Related links
+
+- [Optimization Playbook](/docs/patterns/optimization-playbook) — systematic profiling and gas reduction
+- [Storage Patterns](/docs/concepts/storage) — storage cost drivers
+- [Building and Compilation](/docs/getting-started/building-and-compilation) — release builds and WASM size

--- a/documentation/docs/concepts/introduction.md
+++ b/documentation/docs/concepts/introduction.md
@@ -1,4 +1,8 @@
-# What is Soroban?
+---
+title: What is Soroban?
+description: Introduction to Soroban, Stellar's smart contract platform.
+sidebar_position: 1
+---
 
 Welcome to Soroban, Stellar's smart contract platform. This guide introduces you to Soroban and explains why it matters in the Stellar ecosystem.
 
@@ -183,7 +187,7 @@ With Soroban, you can create:
 
 ## Resources
 
-- [Official Soroban Documentation](https://developers.stellar.org/docs/smart-contracts)
+- [Official Soroban Documentation](https://developers.stellar.org/docs/build/smart-contracts)
 - [Soroban SDK Reference](https://docs.rs/soroban-sdk)
 - [Soroban Examples Repository](https://github.com/stellar/soroban-examples)
 - [Stellar Developer Discord](https://discord.gg/stellardev)
@@ -194,5 +198,5 @@ With Soroban, you can create:
 Join the community:
 
 - **Discord** - [Stellar Developer Community](https://discord.gg/stellardev)
-- **GitHub** - [Soroban Cookbook Discussions](https://github.com/Soroban-Cookbook/Soroban-Cookbook-/discussions)
+- **GitHub** - [Soroban Cookbook Issues](https://github.com/Soroban-Cookbook/Soroban_Cookbook_online/issues)
 - **Stack Overflow** - Tag your questions with `soroban`

--- a/documentation/docs/concepts/overview.md
+++ b/documentation/docs/concepts/overview.md
@@ -1,4 +1,8 @@
-# Core Concepts
+---
+title: Core Concepts
+description: Essential concepts for building Soroban smart contracts.
+sidebar_position: 2
+---
 
 Essential concepts for building Soroban smart contracts.
 
@@ -8,23 +12,23 @@ Understanding these core concepts will help you build robust and efficient Sorob
 
 ## Key Topics
 
-### Storage & State Management
+### [Storage & State Management](/docs/concepts/storage)
 
 Learn how to persist data in your contracts using Soroban's storage system.
 
-### Authorization & Access Control
+### [Authorization & Access Control](/docs/concepts/authorization)
 
 Implement secure authentication and authorization patterns.
 
-### Events & Logging
+### [Events & Logging](/docs/concepts/events)
 
 Emit events and logs for contract monitoring and debugging.
 
-### Error Handling
+### [Error Handling](/docs/concepts/error-handling)
 
 Proper error handling and recovery strategies.
 
-### Contract Lifecycle
+### [Contract Lifecycle](/docs/patterns/lifecycle-upgrades)
 
 Understanding deployment, upgrades, and contract lifecycle management.
 
@@ -32,12 +36,13 @@ Understanding deployment, upgrades, and contract lifecycle management.
 
 Start with:
 
-1. [What is Soroban?](./introduction) - Beginner-friendly introduction
-2. [Storage Patterns](./storage) - Learn data persistence
-3. [Authorization](./authorization) - Secure your contracts
-4. [Events](./events) - Monitor contract activity
+1. [What is Soroban?](/docs/concepts/introduction) — Beginner-friendly introduction
+2. [Soroban Best Practices](/docs/concepts/best-practices) — do/don't rules for new developers
+3. [Storage Patterns](/docs/concepts/storage) — Learn data persistence
+4. [Authorization](/docs/concepts/authorization) — Secure your contracts
+5. [Events](/docs/concepts/events) — Monitor contract activity
 
 ## Resources
 
-- [Soroban Documentation](https://developers.stellar.org/docs/smart-contracts)
+- [Soroban Documentation](https://developers.stellar.org/docs/build/smart-contracts)
 - [SDK Reference](https://docs.rs/soroban-sdk)

--- a/documentation/docs/concepts/storage.md
+++ b/documentation/docs/concepts/storage.md
@@ -1,4 +1,8 @@
-# Storage Patterns
+---
+title: Storage Patterns
+description: Instance, persistent, and temporary storage types in Soroban contracts.
+sidebar_position: 4
+---
 
 Soroban contracts use three storage types: **instance**, **persistent**, and **temporary**. Each storage type has a different lifetime, cost profile, and common use case.
 
@@ -222,6 +226,6 @@ Concrete heuristics:
 
 - [Hello World Storage](/docs/patterns/hello-world) — simple instance storage example
 - [Error Recovery](/docs/patterns/error-recovery) — storage usage in resilient smart contracts
-- [Authorization](/docs/concepts/authorization.md)
+- [Authorization](/docs/concepts/authorization)
 - [Security Fundamentals](/docs/security/fundamentals.md)
 - [First Contract Walkthrough](/docs/getting-started/first-contract.md)

--- a/documentation/docs/contributing.md
+++ b/documentation/docs/contributing.md
@@ -1,10 +1,8 @@
 ---
 sidebar_position: 10
-title: Contributing Guide
+title: Contributing to Soroban Cookbook
 description: Learn how to contribute to the Soroban Cookbook project.
 ---
-
-# Contributing to Soroban Cookbook
 
 First off, thank you for considering contributing to the Soroban Cookbook! It's people like you that make this a great resource for the Stellar community.
 
@@ -32,7 +30,7 @@ We welcome several types of contributions:
 To contribute code or documentation changes, you'll need to set up the project locally.
 
 ### Prerequisites
-- **Rust & Soroban CLI:** [Install Rust](https://www.rust-lang.org/tools/install) and the [Soroban CLI](https://developers.stellar.org/docs/smart-contracts/getting-started/setup#install-the-soroban-cli).
+- **Rust & Soroban CLI:** [Install Rust](https://www.rust-lang.org/tools/install) and the [Soroban CLI](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli).
 - **Bun:** We use [Bun](https://bun.sh/) as our primary JavaScript runtime and package manager.
 - **Git:** For version control.
 
@@ -97,7 +95,7 @@ Contract examples should be minimal, focused, and well-documented.
 
 - **Storage:** Use `examples/` for standalone Rust projects (if applicable).
 - **Inline Docs:** Explain complex logic within the Rust code snippets using comments.
-- **Best Practices:** Follow [Soroban Best Practices](https://developers.stellar.org/docs/smart-contracts/best-practices/security-checklist).
+- **Best Practices:** Follow [Soroban Best Practices](https://developers.stellar.org/docs/build/smart-contracts/example-contracts).
 
 ### C. Fixes & Improvements
 - **Scope:** Keep PRs small. Avoid unrelated refactors in the same PR.
@@ -160,9 +158,17 @@ Expect some feedback! We might ask for clarifications or small adjustments. This
 
 ## 📞 Getting Help
 If you're stuck, feel free to:
-- Open a [GitHub Discussion](https://github.com/Soroban-Cookbook/Soroban_Cookbook_online/discussions).
+- Open a [GitHub Issue](https://github.com/Soroban-Cookbook/Soroban_Cookbook_online/issues).
 - Join the [Stellar Dev Discord](https://discord.gg/stellardev) and ask in the `#soroban` channel.
 
 ---
 
 **Thank you for helping us build the best Soroban resource! 🚀**
+
+---
+
+## Related links
+
+- [Internal Linking Strategy](/docs/contributing/internal-linking) — how we structure cross-links for SEO and navigation
+- [Adding a Tested Code Example](/docs/contributing/add-tested-example) — contribute verified examples
+- [Pattern Library](/docs/patterns/overview) — where new patterns are catalogued

--- a/documentation/docs/contributing/add-tested-example.md
+++ b/documentation/docs/contributing/add-tested-example.md
@@ -4,8 +4,6 @@ description: How to contribute a new Soroban code example that is validated auto
 sidebar_position: 2
 ---
 
-# Adding a Tested Code Example
-
 Every code example in the Soroban Cookbook lives in the `examples/` directory at the root of the repository. Each example is a self-contained Rust crate with its own `Cargo.toml` and `src/lib.rs`. The CI pipeline runs `cargo test` for every example on every pull request, so all published snippets are always verified.
 
 ## Directory layout
@@ -152,10 +150,18 @@ If your PR introduces a new example, CI will automatically pick it up because th
 Install Rust: https://www.rust-lang.org/tools/install
 
 **`soroban_sdk` version mismatch**
-Check the latest version on [crates.io](https://crates.io/crates/soroban-sdk) and update `Cargo.toml` accordingly.
+Check the latest version on [docs.rs](https://docs.rs/soroban-sdk/latest) and update `Cargo.toml` accordingly.
 
 **Test compilation errors**
 Make sure `[lib] crate-type` includes `"rlib"`. Without it, the test harness cannot link the crate.
 
 **`env.register` vs `env.register_contract`**
 Use `env.register(MyContract, ())` (SDK ≥ 21). The older `env.register_contract` was removed in recent releases.
+
+---
+
+## Related links
+
+- [Contributing Guide](/docs/contributing) — full contribution workflow
+- [Pattern Library](/docs/patterns/overview) — where examples are documented
+- [Internal Linking Strategy](/docs/contributing/internal-linking) — link new pages into the site graph

--- a/documentation/docs/contributing/image-optimization.md
+++ b/documentation/docs/contributing/image-optimization.md
@@ -3,8 +3,6 @@ title: Image Optimization Guidelines
 description: Best practices for using images in Soroban Cookbook documentation
 ---
 
-# Image Optimization Guidelines
-
 This guide covers best practices for using images in the Soroban Cookbook documentation to ensure optimal performance and user experience.
 
 ## Quick Start
@@ -193,3 +191,11 @@ Before adding new images:
 - **404 page**: Reduced from 1.9MB to ~50KB (97% reduction)
 - **Social cards**: Reduced by 60-80%
 - **Overall site weight**: Reduced by 40-60%
+
+---
+
+## Related links
+
+- [Contributing Guide](/docs/contributing) — documentation contribution workflow
+- [Image Optimization Performance Impact](/docs/contributing/performance-impact) — before/after metrics
+- [Empty States](/docs/design-system/empty-states) — image usage in UI patterns

--- a/documentation/docs/contributing/internal-linking.md
+++ b/documentation/docs/contributing/internal-linking.md
@@ -1,0 +1,156 @@
+---
+title: Internal Linking Strategy
+description: How to structure cross-links across the Soroban Cookbook for SEO, discoverability, and reader navigation.
+sidebar_position: 3
+---
+
+Internal links connect related pages so readers and search engines can discover content in context. This guide defines the cookbook's linking model and how to keep it healthy in CI.
+
+---
+
+## Goals
+
+1. **Navigation** — readers always have a clear next step and related reading.
+2. **SEO** — crawlers map topical clusters (getting started → concepts → patterns → security).
+3. **Maintainability** — required links are declared in one registry and checked automatically.
+
+---
+
+## Hub-and-spoke model
+
+Four **hub pages** anchor each major section. Every leaf page should link back to its hub and to at least one peer or downstream page.
+
+| Hub | URL | Role |
+|-----|-----|------|
+| Docs home | `/docs/` | Entry point; links to all major sections |
+| Core Concepts | `/docs/concepts/overview` | Concept index |
+| Pattern Library | `/docs/patterns/overview` | Pattern catalog |
+| Security | `/docs/security/fundamentals` | Security baseline |
+
+**Category hubs** (implicit via sidebar): Getting Started (`/docs/getting-started/setup`), Contributing (`/docs/contributing`).
+
+---
+
+## Link format
+
+Prefer **root-relative doc paths** so links survive file moves and match Docusaurus routing:
+
+```markdown
+[Storage Patterns](/docs/concepts/storage)
+```
+
+Acceptable alternatives in existing pages (audit normalizes these):
+
+- `[Storage Patterns](./storage.md)` from sibling concept pages
+- `[Storage Patterns](../concepts/storage.md)` from other sections
+
+Avoid bare filenames without path context in new content. Use descriptive anchor text — not "click here".
+
+---
+
+## Required page sections
+
+Every tutorial, concept, pattern, and security page should end with a navigation block:
+
+```markdown
+---
+
+## Related links
+
+- [Next Page Title](/docs/path/to/page) — one-line description
+- [Related Topic](/docs/path/to/other) — why it matters
+```
+
+Accepted section headings (pick one):
+
+- `## Related links` (preferred for new content)
+- `## Next steps` / `## Next Steps` — learning-path pages
+- `## Related Topics` / `## Related Patterns` — pattern pages
+
+Include **2–4 internal links** minimum. At least one should point forward in the learning path or to a security doc when handling value or auth.
+
+---
+
+## Learning paths
+
+### Getting Started
+
+`/docs/getting-started/setup` → first contract → building → local testing → deploy testnet → deploy mainnet → contract interaction
+
+Branch: [Debugging](/docs/getting-started/debugging) and [Testing errors](/docs/getting-started/testing-errors) from any build/test page.
+
+### Core Concepts
+
+`/docs/concepts/introduction` → overview → best practices → storage → authorization → events → gas & resources → cross-contract invocation
+
+### Patterns
+
+`/docs/patterns/overview` → hello world → custom types → authorization → optimization → lifecycle upgrades → proposal lifecycle
+
+Cross-link [Error handling](/docs/patterns/error-handling) and [Error recovery](/docs/patterns/error-recovery) from overview and concepts.
+
+### Security
+
+`/docs/security/fundamentals` → [Token audit](/docs/security/token-audit) → [Governance](/docs/security/governance)
+
+Link security docs from deploy-mainnet, authorization, and token-related patterns.
+
+---
+
+## Registry and CI
+
+Required links per page live in `documentation/scripts/link-registry.json` in the repository.
+
+When you add or restructure a doc:
+
+1. Add an entry to `link-registry.json` with `requiredLinks` and `minInternalLinks`.
+2. Add a `## Related links` section to the page.
+3. Update the relevant **hub page** if the page is a major topic.
+4. Run the audit:
+
+```bash
+cd documentation
+bun run audit:links
+```
+
+The CI **Lint & Format** job runs this check on every pull request.
+
+---
+
+## External links
+
+Docusaurus `onBrokenLinks: 'throw'` validates **internal** doc routes at build time. **External** URLs are checked separately:
+
+```bash
+cd documentation
+bun run check:external-links
+```
+
+- Scans `docs/` and `src/` for `http(s)://` links in markdown and JSX.
+- Writes a report to `reports/external-links.md` (gitignored; uploaded as a CI artifact).
+- Skips localhost, RPC endpoints, and template placeholders (`[...]`, `<...>`).
+- Ignored URLs are listed in `scripts/external-link-ignore.json`.
+- Fails CI when any checked URL returns a non-success HTTP status.
+
+When adding external links, prefer stable official docs (Stellar, Rust, GitHub) over short-lived third-party URLs.
+
+---
+
+## Checklist for new pages
+
+- [ ] Frontmatter `title` and `description` set (SEO metadata).
+- [ ] Linked from at least one hub or sibling page (no orphans).
+- [ ] `## Related links` section with 2–4 internal links.
+- [ ] Entry added to `link-registry.json`.
+- [ ] Hub page updated if this is a flagship topic.
+- [ ] `bun run audit:links` passes.
+- [ ] `bun run check:external-links` passes (or no new external URLs added).
+
+---
+
+## Related links
+
+- [Contributing Guide](/docs/contributing) — contribution workflow
+- [Pattern Library](/docs/patterns/overview) — pattern hub
+- [Core Concepts](/docs/concepts/overview) — concepts hub
+- [Security Fundamentals](/docs/security/fundamentals) — security hub

--- a/documentation/docs/contributing/performance-impact.md
+++ b/documentation/docs/contributing/performance-impact.md
@@ -3,8 +3,6 @@ title: Image Optimization Performance Impact
 description: Before and after metrics for image optimization implementation
 ---
 
-# Image Optimization Performance Impact
-
 This document outlines the performance improvements achieved through implementing image optimization best practices in the Soroban Cookbook.
 
 ## Summary of Changes
@@ -133,3 +131,11 @@ The image optimization implementation has resulted in:
 - **Better user experience** across all devices and connection speeds
 
 These improvements directly contribute to better SEO rankings, user retention, and overall site performance. The implemented solution is maintainable, scalable, and follows modern web performance best practices.
+
+---
+
+## Related links
+
+- [Contributing Guide](/docs/contributing) — documentation standards
+- [Image Optimization Guidelines](/docs/contributing/image-optimization) — how to optimize images in docs
+- [Internal Linking Strategy](/docs/contributing/internal-linking) — SEO and navigation conventions

--- a/documentation/docs/design-system/alerts-callouts.mdx
+++ b/documentation/docs/design-system/alerts-callouts.mdx
@@ -7,8 +7,6 @@ description: Alert and callout components for important messages and documentati
 import { Alert } from '@site/src/components/Alert';
 import { Callout } from '@site/src/components/Callout';
 
-# Alerts & Callouts
-
 Standardized components for displaying important messages, warnings, and informational content with visual emphasis.
 
 ## Alert Component
@@ -299,3 +297,11 @@ All variants are optimized for both light and dark themes with appropriate color
 </div>
 
 Toggle your theme to see how the components adapt automatically.
+
+---
+
+## Related links
+
+- [Alerts Component](/docs/components/alerts) — React alert reference
+- [Callouts Component](/docs/components/callouts) — callout variants
+- [Alert & Callout Showcase](/docs/components/alert-callout-showcase) — full feature demo

--- a/documentation/docs/design-system/badges-tags.mdx
+++ b/documentation/docs/design-system/badges-tags.mdx
@@ -6,8 +6,6 @@ sidebar_label: Badges & Tags
 
 import { Badge, Tag } from '@site/src/components/Badge';
 
-# Badges & Tags
-
 Badges are small status indicators. Tags are categorical labels. Both are compact, color-coded, and accessible.
 
 The `Badge` and `Tag` React components are the canonical way to render these in docs and components. They map directly to the global `.sb-badge` / `.sb-tag` CSS classes in `badges-tags.css`.
@@ -223,3 +221,11 @@ When the badge is the only difficulty signal, use `asStatus` (React) or `role="s
 ```
 
 For clickable badges/tags, always use `<button>` or `<a>` — never `<span>` with `onClick`.
+
+---
+
+## Related links
+
+- [Typography System](/docs/design-system/typography) — type scale used with badges
+- [Pattern Library](/docs/patterns/overview) — difficulty and category tags on patterns
+- [Button System](/docs/design-system/buttons) — companion interactive tokens

--- a/documentation/docs/design-system/buttons.mdx
+++ b/documentation/docs/design-system/buttons.mdx
@@ -4,8 +4,6 @@ description: Visual variants, sizes, states, icon integration, button groups, ac
 sidebar_label: Buttons
 ---
 
-# Button System
-
 The button component lives in `src/components/buttons/Button.tsx` with CSS module tokens in `buttons.module.css`.
 
 ```tsx
@@ -265,3 +263,11 @@ Where `{variant}` is `primary`, `secondary`, `tertiary`, `ghost`, or `danger`.
 - Use `danger` for non-destructive actions just because you want red
 - Disable buttons without explaining why (add a tooltip or helper text)
 - Nest interactive elements inside a button
+
+---
+
+## Related links
+
+- [Typography System](/docs/design-system/typography) — type scale and heading hierarchy
+- [Button Component](/docs/components/buttons) — React component reference
+- [Badges & Tags](/docs/design-system/badges-tags) — companion UI tokens

--- a/documentation/docs/design-system/empty-states.mdx
+++ b/documentation/docs/design-system/empty-states.mdx
@@ -6,8 +6,6 @@ sidebar_label: Empty States
 
 import EmptyState from '@site/src/components/EmptyState/EmptyState';
 
-# Empty States
-
 Empty states appear when there's no content to display — a search returns nothing, a pattern list is empty, or a section hasn't been populated yet. A good empty state reduces confusion by explaining _why_ content is missing and offering a clear next step.
 
 ---
@@ -79,7 +77,7 @@ Three sizes to match the surrounding context.
   title="No patterns available"
   body="This category doesn't have any patterns yet. Check back soon or contribute one."
   actions={[
-    { label: 'Contribute a pattern', href: 'https://github.com/Soroban-Cookbook/Soroban-Cookbook-/blob/main/CONTRIBUTING.md' },
+    { label: 'Contribute a pattern', href: 'https://github.com/Soroban-Cookbook/Soroban_Cookbook_online/blob/main/CONTRIBUTING.md' },
     { label: 'Browse all patterns', variant: 'secondary', href: '/docs/patterns/overview' },
   ]}
 />
@@ -139,7 +137,7 @@ Use when a pattern category exists but has no entries yet.
   title="No DeFi patterns yet"
   body="We're working on it. In the meantime, explore token standards or contribute a pattern."
   actions={[
-    { label: 'Contribute a pattern', href: 'https://github.com/Soroban-Cookbook/Soroban-Cookbook-/blob/main/CONTRIBUTING.md' },
+    { label: 'Contribute a pattern', href: 'https://github.com/Soroban-Cookbook/Soroban_Cookbook_online/blob/main/CONTRIBUTING.md' },
     { label: 'View token patterns', variant: 'secondary', href: '/docs/patterns/overview' },
   ]}
 />
@@ -203,3 +201,11 @@ Use when a pattern category exists but has no entries yet.
 ```tsx
 import { EmptyState } from '@site/src/components/EmptyState';
 ```
+
+---
+
+## Related links
+
+- [Button System](/docs/design-system/buttons) — primary actions in empty states
+- [Testimonials Component](/docs/components/testimonials) — community section layout
+- [Typography System](/docs/design-system/typography) — heading and body styles

--- a/documentation/docs/design-system/typography.mdx
+++ b/documentation/docs/design-system/typography.mdx
@@ -4,8 +4,6 @@ description: Font families, type scale, heading hierarchy, responsive sizing, an
 sidebar_label: Typography
 ---
 
-# Typography System
-
 A consistent type system for readable, accessible content across the Soroban Cookbook.
 
 ---
@@ -92,6 +90,10 @@ h3 {
 
 :::caution
 Never skip heading levels (e.g. `h1` → `h3`). Screen readers rely on the heading tree for navigation.
+:::
+
+:::tip Docusaurus docs convention
+Set the page title in frontmatter (`title:`) — Docusaurus renders it as the sole `h1`. Start page body content with `##` sections; do not add a duplicate `#` heading in the markdown. Run `bun run audit:headings` to validate the site.
 :::
 
 ---
@@ -207,3 +209,12 @@ All text colors are already defined in `custom.css` for both light and dark them
 - Use `line-height` below `1.4` for multi-line body text
 - Set text color with raw hex — use the existing `--ifm-*` tokens so dark mode works
 - Use `font-weight: bold` on large blocks of text — reserve bold for emphasis
+
+---
+
+## Related links
+
+- [Button System](/docs/design-system/buttons) — interactive control tokens
+- [Iconography](/docs/components/iconography) — icon usage in UI
+- [Responsive Breakpoints](/docs/responsive/breakpoints) — responsive type utilities
+- [Internal Linking Strategy](/docs/contributing/internal-linking) — doc navigation conventions

--- a/documentation/docs/getting-started/building-and-compilation.md
+++ b/documentation/docs/getting-started/building-and-compilation.md
@@ -4,8 +4,6 @@ description: A complete guide to compiling Soroban smart contracts — from sour
 sidebar_position: 4
 ---
 
-# Building and Compilation
-
 This guide walks through the complete compilation pipeline for Soroban contracts: from Rust source code to a deployable WebAssembly (WASM) artifact. You will learn how each build step works, how to control build flags for debug versus release output, and how to diagnose common compilation errors.
 
 ## Prerequisites
@@ -378,14 +376,15 @@ stellar contract deploy \
 
 ## Next steps
 
-- [Deploy to Testnet](./deploy-testnet.md) — put your compiled contract on the network
-- [Contract Interaction](./contract-interaction.md) — invoke functions on a deployed contract
-- [Gas and Resource Management](../concepts/gas-and-resources.md) — understand and optimise on-chain costs
-- [Optimization Playbook](../patterns/optimization-playbook.mdx) — advanced size and performance patterns
+- [Local Testing and Simulation](/docs/getting-started/local-testing-and-simulation) — test before deploying
+- [Deploy to Testnet](/docs/getting-started/deploy-testnet) — put your compiled contract on the network
+- [Contract Interaction](/docs/getting-started/contract-interaction) — invoke functions on a deployed contract
+- [Gas and Resource Management](/docs/concepts/gas-and-resources) — understand and optimise on-chain costs
+- [Optimization Playbook](/docs/patterns/optimization-playbook) — advanced size and performance patterns
 
 ## Additional resources
 
-- [Soroban CLI reference](https://developers.stellar.org/docs/smart-contracts/soroban-cli)
+- [Soroban CLI reference](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli)
 - [Cargo profiles](https://doc.rust-lang.org/cargo/reference/profiles.html)
 - [wasm-opt — Binaryen](https://github.com/WebAssembly/binaryen)
-- [Soroban SDK on crates.io](https://crates.io/crates/soroban-sdk)
+- [Soroban SDK on docs.rs](https://docs.rs/soroban-sdk/latest)

--- a/documentation/docs/getting-started/contract-interaction.md
+++ b/documentation/docs/getting-started/contract-interaction.md
@@ -263,6 +263,7 @@ const response = await fetch("/api/contract/invoke", {
 
 ## Related resources
 
+- [Pattern Library](/docs/patterns/overview) — reusable contract patterns
 - [Deploy to testnet](/docs/getting-started/deploy-testnet)
 - [First contract tutorial](/docs/getting-started/first-contract)
 - [Error handling patterns](/docs/patterns/error-recovery)

--- a/documentation/docs/getting-started/debugging.md
+++ b/documentation/docs/getting-started/debugging.md
@@ -3,8 +3,6 @@ title: Debugging Guide
 description: Systematic debugging workflows and practical troubleshooting techniques for Soroban smart contract development
 ---
 
-# Debugging Guide
-
 Learn systematic debugging techniques to quickly identify and resolve issues in your contract development. This guide covers the debugging workflow, common issues across different failure categories, and practical development tools.
 
 ## Systematic Debugging Workflow
@@ -113,11 +111,11 @@ echo $PATH
 1. **Install Soroban CLI** (if not installed):
    ```bash
    # macOS/Linux
-   curl --proto '=https' --tlsv1.2 -sSf https://install.stellar.org/soroban-cli | bash
+   curl -fsSL https://github.com/stellar/stellar-cli/raw/main/install.sh | sh
    source ~/.bashrc  # or ~/.zshrc for zsh
    
    # Windows (with WSL)
-   curl --proto '=https' --tlsv1.2 -sSf https://install.stellar.org/soroban-cli | bash
+   curl -fsSL https://github.com/stellar/stellar-cli/raw/main/install.sh | sh
    source ~/.bashrc
    ```
 
@@ -770,7 +768,7 @@ Before asking for help, verify:
 
 - [Error Handling in Soroban](../concepts/error-handling.md) - Detailed error patterns
 - [Testing Error Scenarios](./testing-errors.md) - Comprehensive error testing
-- [Soroban Documentation](https://developers.stellar.org/soroban) - Official docs
+- [Soroban Documentation](https://developers.stellar.org/docs/build/smart-contracts) - Official docs
 - [Rust Book](https://doc.rust-lang.org/book/) - Rust fundamentals
 
 ---

--- a/documentation/docs/getting-started/deploy-mainnet.md
+++ b/documentation/docs/getting-started/deploy-mainnet.md
@@ -4,8 +4,6 @@ description: A risk-aware guide to deploying Soroban smart contracts to Stellar 
 sidebar_position: 6
 ---
 
-# Deploy to Mainnet
-
 Deploying to Stellar mainnet is a one-way door: **there is no undo**. Bugs ship with real financial consequences, and the cost to remediate a vulnerability after deployment is always higher than the cost to prevent it before. This guide walks through every stage of a production deployment — from pre-deploy verification through post-deploy monitoring — with explicit safety controls at each step.
 
 > **Complete [Deploy to Testnet](./deploy-testnet.md) first.** Every step in this guide assumes your contract has been deployed, invoked, and fully validated on testnet.
@@ -376,5 +374,5 @@ Copy this checklist into your release notes for every mainnet deployment.
 
 - [Stellar Expert block explorer](https://stellar.expert/explorer/public)
 - [Stellar Status page](https://status.stellar.org)
-- [Soroban CLI reference](https://developers.stellar.org/docs/smart-contracts/soroban-cli)
+- [Soroban CLI reference](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli)
 - [Stellar Discord — #soroban channel](https://discord.gg/stellardev)

--- a/documentation/docs/getting-started/deploy-testnet.md
+++ b/documentation/docs/getting-started/deploy-testnet.md
@@ -1,4 +1,8 @@
-# Deploy to Testnet
+---
+title: Deploy to Testnet
+description: Deploy your Soroban contract to Stellar testnet for validation in a live network environment.
+sidebar_position: 5
+---
 
 Deploy your Soroban contract to Stellar testnet for validation in a live network environment. This guide covers the complete workflow from contract artifact to verification.
 
@@ -503,24 +507,24 @@ soroban account transactions --account my-testnet-account --network testnet
 
 Now that your contract is deployed:
 
-1. **Test thoroughly** - Invoke all contract functions and verify behavior
-2. **Monitor events** - Check contract events and logs
-3. **Prepare for mainnet** - When ready, follow similar steps for mainnet deployment
-4. **Learn more** - Explore [Core Concepts](../concepts/overview.md) and [Patterns](../patterns/overview.md)
+1. **Test thoroughly** — Invoke all contract functions and verify behavior
+2. **Monitor events** — Check contract events and logs
+3. **Prepare for mainnet** — [Deploy to Mainnet](/docs/getting-started/deploy-mainnet) when validation is complete
+4. **Learn more** — Explore [Core Concepts](/docs/concepts/overview) and [Patterns](/docs/patterns/overview)
 
 ## Additional Resources
 
-- [Soroban CLI Documentation](https://developers.stellar.org/docs/smart-contracts/soroban-cli)
+- [Soroban CLI Documentation](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli)
 - [Stellar Testnet](https://developers.stellar.org/docs/fundamentals-and-concepts/testnet-public-network)
 - [Soroban SDK Reference](https://docs.rs/soroban-sdk)
-- [Stellar Expert Testnet Explorer](https://testnet.stellar.expert)
+- [Stellar Expert Testnet Explorer](https://stellar.expert/explorer/testnet)
 - [Stellar Discord Community](https://discord.gg/stellardev)
 
 ## Need Help?
 
 If you encounter issues not covered in this guide:
 
-1. Check the [Soroban Documentation](https://developers.stellar.org/docs/smart-contracts)
-2. Search [GitHub Issues](https://github.com/Soroban-Cookbook/Soroban-Cookbook-/issues)
+1. Check the [Soroban Documentation](https://developers.stellar.org/docs/build/smart-contracts)
+2. Search [GitHub Issues](https://github.com/Soroban-Cookbook/Soroban_Cookbook_online/issues)
 3. Ask in the [Stellar Discord](https://discord.gg/stellardev)
 4. Create a new issue with your error message and contract code

--- a/documentation/docs/getting-started/first-contract.md
+++ b/documentation/docs/getting-started/first-contract.md
@@ -1,4 +1,8 @@
-# Your First Contract
+---
+title: Your First Contract
+description: Learn how to create, build, and test your first Soroban smart contract.
+sidebar_position: 4
+---
 
 Learn how to create, build, and test your first Soroban smart contract.
 
@@ -76,9 +80,10 @@ cargo test
 
 ## Next Steps
 
-- [Deploy to testnet](./deploy-testnet)
-- [Learn about storage](../concepts/storage)
-- [Explore patterns](../patterns/overview.md)
+- [Building and Compilation](/docs/getting-started/building-and-compilation) — compile your contract to WASM
+- [Deploy to testnet](/docs/getting-started/deploy-testnet)
+- [Learn about storage](/docs/concepts/storage)
+- [Explore patterns](/docs/patterns/overview)
 
 ## Resources
 

--- a/documentation/docs/getting-started/local-testing-and-simulation.md
+++ b/documentation/docs/getting-started/local-testing-and-simulation.md
@@ -5,8 +5,6 @@ description: Test and simulate your Soroban contracts locally before deploying t
 image: /img/soroban-social-card.png
 ---
 
-# Local Testing and Simulation
-
 Test your Soroban contracts in a local sandbox environment before deploying to testnet. This guide covers the complete local development workflow — from unit tests and CLI sandbox invocation to state inspection and debugging loops.
 
 ## Prerequisites
@@ -674,7 +672,7 @@ When you are ready, proceed to:
 ## Additional Resources
 
 - [Soroban SDK Testutils](https://docs.rs/soroban-sdk/latest/soroban_sdk/testutils/index.html)
-- [Soroban CLI Reference](https://developers.stellar.org/docs/smart-contracts/soroban-cli)
+- [Soroban CLI Reference](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli)
 - [Rust Testing Documentation](https://doc.rust-lang.org/book/ch11-00-testing.html)
 - [Debugging Guide](./debugging.md)
 - [Testing Error Scenarios](./testing-errors.md)

--- a/documentation/docs/getting-started/setup-linux.md
+++ b/documentation/docs/getting-started/setup-linux.md
@@ -1,4 +1,8 @@
-# Linux Environment Setup
+---
+title: Linux Environment Setup
+description: Set up your Soroban development environment on Linux.
+sidebar_position: 3
+---
 
 Set up your Soroban development environment on Linux to start building smart contracts. This guide covers Ubuntu/Debian-based distributions with notes for other Linux distros.
 
@@ -310,7 +314,7 @@ Now that your Linux environment is ready:
 ## Additional Resources
 
 - [Rust Installation Guide](https://www.rust-lang.org/tools/install)
-- [Soroban Official Documentation](https://developers.stellar.org/docs/smart-contracts)
+- [Soroban Official Documentation](https://developers.stellar.org/docs/build/smart-contracts)
 - [Stellar Discord Community](https://discord.gg/stellardev)
 - [Linux Package Management Guide](https://wiki.archlinux.org/title/Pacman/Rosetta)
 
@@ -318,7 +322,7 @@ Now that your Linux environment is ready:
 
 If you encounter issues not covered in this guide:
 
-1. Check the [Soroban Documentation](https://developers.stellar.org/docs/smart-contracts)
+1. Check the [Soroban Documentation](https://developers.stellar.org/docs/build/smart-contracts)
 2. Ask in the [Stellar Discord](https://discord.gg/stellardev)
-3. Search existing [GitHub Issues](https://github.com/Soroban-Cookbook/Soroban-Cookbook-/issues)
+3. Search existing [GitHub Issues](https://github.com/Soroban-Cookbook/Soroban_Cookbook_online/issues)
 4. Create a new issue with detailed error messages and your Linux distribution info

--- a/documentation/docs/getting-started/setup-windows.md
+++ b/documentation/docs/getting-started/setup-windows.md
@@ -1,4 +1,8 @@
-# Windows Environment Setup
+---
+title: Windows Environment Setup
+description: Complete guide to setting up Soroban development on Windows with WSL 2.
+sidebar_position: 2
+---
 
 Set up your Soroban development environment on Windows. This guide covers both WSL (Windows Subsystem for Linux) - the recommended approach - and native Windows installation.
 
@@ -663,7 +667,7 @@ Now that your Windows environment is set up:
 
 - [WSL Documentation](https://learn.microsoft.com/en-us/windows/wsl/)
 - [Rust Installation Guide](https://www.rust-lang.org/tools/install)
-- [Soroban CLI Documentation](https://developers.stellar.org/docs/smart-contracts/soroban-cli)
+- [Soroban CLI Documentation](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli)
 - [VS Code Remote WSL](https://code.visualstudio.com/docs/remote/wsl)
 - [Git for Windows](https://git-scm.com/download/win)
 - [Stellar Discord Community](https://discord.gg/stellardev)
@@ -672,7 +676,7 @@ Now that your Windows environment is set up:
 
 If you encounter issues not covered in this guide:
 
-1. Check the [Soroban Documentation](https://developers.stellar.org/docs/smart-contracts)
-2. Search [GitHub Issues](https://github.com/Soroban-Cookbook/Soroban-Cookbook-/issues)
+1. Check the [Soroban Documentation](https://developers.stellar.org/docs/build/smart-contracts)
+2. Search [GitHub Issues](https://github.com/Soroban-Cookbook/Soroban_Cookbook_online/issues)
 3. Ask in the [Stellar Discord](https://discord.gg/stellardev)
 4. Create a new issue with your error message and Windows version info

--- a/documentation/docs/getting-started/setup.md
+++ b/documentation/docs/getting-started/setup.md
@@ -1,6 +1,10 @@
-# Environment Setup
+---
+title: Environment Setup
+description: Set up your Soroban development environment to start building smart contracts.
+sidebar_position: 1
+---
 
-Set up your Soroban development environment to start building smart contracts.
+For platform-specific instructions, see [Linux Environment Setup](/docs/getting-started/setup-linux) or [Windows Environment Setup](/docs/getting-started/setup-windows).
 
 ## Prerequisites
 
@@ -83,4 +87,4 @@ Now that your environment is ready:
 **Need Help?**
 
 - [Stellar Discord](https://discord.gg/stellardev)
-- [Soroban Documentation](https://developers.stellar.org/docs/smart-contracts)
+- [Soroban Documentation](https://developers.stellar.org/docs/build/smart-contracts)

--- a/documentation/docs/getting-started/testing-errors.md
+++ b/documentation/docs/getting-started/testing-errors.md
@@ -4,8 +4,6 @@ description: Guide to testing error handling in Soroban contracts
 sidebar_position: 6
 ---
 
-# Testing Error Scenarios
-
 ## Overview
 
 Comprehensive error testing ensures your contract handles failures gracefully and maintains security. This guide covers testing strategies for error conditions in Soroban smart contracts.
@@ -448,6 +446,6 @@ When error tests fail:
 
 ## Additional Resources
 
-- [Soroban Testing Guide](https://developers.stellar.org/docs/smart-contracts/testing)
+- [Soroban Testing Guide](https://developers.stellar.org/docs/build/smart-contracts/example-contracts)
 - [Rust Testing Documentation](https://doc.rust-lang.org/book/ch11-00-testing.html)
 - [Soroban SDK Test Utils](https://docs.rs/soroban-sdk/latest/soroban_sdk/testutils/)

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -1,11 +1,9 @@
 ---
 sidebar_position: 1
-title: Welcome
+title: Welcome to Soroban Cookbook
 description: Your comprehensive guide to building smart contracts on Stellar with Soroban — patterns, tutorials, and best practices.
 image: /img/soroban-social-card.png
 ---
-
-# Welcome to Soroban Cookbook
 
 Your comprehensive guide to building smart contracts on Stellar.
 
@@ -32,17 +30,18 @@ Build production-ready smart contracts on Soroban, from basic concepts to advanc
 
 ## 🎯 Quick Links
 
-- [What is Soroban?](./concepts/introduction.md) - Beginner-friendly introduction
-- [Getting Started](./getting-started/setup.md) - Set up your development environment
-- [Core Concepts](./concepts/overview.md) - Learn Soroban fundamentals
-- [Patterns](./patterns/overview.md) - Reusable contract patterns
+- [What is Soroban?](/docs/concepts/introduction) — Beginner-friendly introduction
+- [Getting Started](/docs/getting-started/setup) — Set up your development environment
+- [Core Concepts](/docs/concepts/overview) — Learn Soroban fundamentals
+- [Patterns](/docs/patterns/overview) — Reusable contract patterns
+- [Security](/docs/security/fundamentals) — Security fundamentals and audit checklists
 
 ## 🤝 Community
 
 Join the Soroban community:
 
-- [Stellar Discord](https://discord.gg/stellardev) - Ask questions and get help
-- [GitHub Discussions](https://github.com/Soroban-Cookbook/Soroban-Cookbook-/discussions) - Share ideas
-- [Stack Overflow](https://stackoverflow.com/questions/tagged/soroban) - Technical Q&A
+- [Stellar Discord](https://discord.gg/stellardev) — Ask questions and get help
+- [GitHub Issues](https://github.com/Soroban-Cookbook/Soroban_Cookbook_online/issues) — Share ideas and report bugs
+- [Stack Overflow](https://stackoverflow.com/questions/tagged/soroban) — Technical Q&A
 
-Ready to start building? Begin with [Environment Setup](./getting-started/setup.md)!
+Ready to start building? Begin with [Environment Setup](/docs/getting-started/setup)!

--- a/documentation/docs/patterns/authorization.mdx
+++ b/documentation/docs/patterns/authorization.mdx
@@ -200,6 +200,7 @@ mod tests {
 
 <PatternSection id="further-reading" title="Further reading">
 
-- Core concepts: see the [Authorization concept](/docs/concepts/authorization.md) page for signer primitives and examples.
+- Core concepts: see the [Authorization concept](/docs/concepts/authorization) page for signer primitives and examples.
+- [Security Fundamentals](/docs/security/fundamentals) — access control checklist
 
 </PatternSection>

--- a/documentation/docs/patterns/custom-types.mdx
+++ b/documentation/docs/patterns/custom-types.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-title: Designing Custom Types
+title: Designing Robust Custom Types
 description: Best practices for modeling, serialization, and evolution of custom data types in Soroban.
 image: /img/soroban-social-card.png
 ---
@@ -10,11 +10,9 @@ import TabItem from "@theme/TabItem";
 import { Callout } from "@site/src/components/Callout";
 import { Alert } from "@site/src/components/Alert";
 
-# Designing Robust Custom Types
-
 ## Overview
 
-In Soroban, types are more than just data containersóthey define the contract's storage footprint, gas efficiency, and long-term maintainability. This guide covers strategies for designing custom types that are robust, efficient, and evolvable.
+In Soroban, types are more than just data containersùthey define the contract's storage footprint, gas efficiency, and long-term maintainability. This guide covers strategies for designing custom types that are robust, efficient, and evolvable.
 
 <Callout variant="info" title="Why Type Design Matters">
 Smart contracts are immutable by nature, but their state persists across upgrades. Poorly designed types can lead to "storage bloat," high gas costs for reads/writes, and complex migrations when business requirements change.

--- a/documentation/docs/patterns/error-handling.mdx
+++ b/documentation/docs/patterns/error-handling.mdx
@@ -241,6 +241,7 @@ Remember that if a contract returns an error, the transaction rolls back, and an
 <PatternSection id="related" title="Related patterns">
 
 - [Error Recovery](/docs/patterns/error-recovery) — strategies for degraded modes and fallback execution.
+- [Error Handling concepts](/docs/concepts/error-handling) — Result types and error taxonomy
 - [Authorization Concepts](/docs/concepts/authorization) — detailed auth handling and its related error paths.
 - [Testing Errors Guide](/docs/getting-started/testing-errors) — more strategies for testing failure scenarios.
 

--- a/documentation/docs/patterns/error-recovery.mdx
+++ b/documentation/docs/patterns/error-recovery.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: Error Recovery
+title: Error Recovery Patterns
 description: Comprehensive error handling patterns for Soroban smart contracts
 image: /img/soroban-social-card.png
 ---
@@ -9,8 +9,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { Callout } from '@site/src/components/Callout';
 import { Alert } from '@site/src/components/Alert';
-
-# Error Recovery Patterns
 
 ## Overview
 
@@ -881,13 +879,14 @@ Before deploying your contract, verify:
 
 ## Related Patterns
 
-- [Storage concepts](/docs/concepts/storage) - Understanding storage for rollback
-- [Authorization](/docs/concepts/authorization) - Auth error handling
-- [Security fundamentals](/docs/security/fundamentals) - Security best practices
+- [Error Handling concepts](/docs/concepts/error-handling) — error taxonomy and Result types
+- [Storage concepts](/docs/concepts/storage) — understanding storage for rollback
+- [Authorization](/docs/concepts/authorization) — auth error handling
+- [Security fundamentals](/docs/security/fundamentals) — security best practices
 - [Hello World](/docs/patterns/hello-world) - Basic pattern structure
 
 ## Additional Resources
 
 - [Rust Error Handling](https://doc.rust-lang.org/book/ch09-00-error-handling.html)
-- [Soroban SDK Errors](https://docs.rs/soroban-sdk/latest/soroban_sdk/contracterror/index.html)
-- [Stellar Developer Docs](https://developers.stellar.org/docs/smart-contracts)
+- [Soroban SDK Errors](https://docs.rs/soroban-sdk/latest/soroban_sdk/)
+- [Stellar Developer Docs](https://developers.stellar.org/docs/build/smart-contracts)

--- a/documentation/docs/patterns/lifecycle-upgrades.mdx
+++ b/documentation/docs/patterns/lifecycle-upgrades.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 6
-title: Lifecycle & Upgrades
+title: Contract Lifecycle & Upgrade Safety
 description: Authoritative guide on contract deployment phases, versioning, and upgrade safety in Soroban.
 image: /img/soroban-social-card.png
 ---
@@ -9,8 +9,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { Callout } from '@site/src/components/Callout';
 import { Alert } from '@site/src/components/Alert';
-
-# Contract Lifecycle & Upgrade Safety
 
 ## Overview
 
@@ -162,6 +160,7 @@ If an upgrade introduces a critical flaw, you must have a plan to recover.
 
 ## Related Topics
 
-- [Optimization Playbook](./optimization-playbook.mdx)
-- [Designing Custom Types](./custom-types.mdx)
-- [Storage Concepts](../concepts/storage.md)
+- [Security Fundamentals](/docs/security/fundamentals) — pre-upgrade security review
+- [Optimization Playbook](/docs/patterns/optimization-playbook)
+- [Designing Custom Types](/docs/patterns/custom-types)
+- [Storage Concepts](/docs/concepts/storage)

--- a/documentation/docs/patterns/optimization-playbook.mdx
+++ b/documentation/docs/patterns/optimization-playbook.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-title: Optimization Playbook
+title: Contract Optimization Playbook
 description: A systematic guide to profiling, benchmarking, and optimizing Soroban smart contracts for gas and performance.
 image: /img/soroban-social-card.png
 ---
@@ -9,8 +9,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { Callout } from '@site/src/components/Callout';
 import { Alert } from '@site/src/components/Alert';
-
-# Contract Optimization Playbook
 
 ## Overview
 
@@ -163,6 +161,7 @@ When submitting an optimization PR, include a "Before & After" table:
 
 ## Related Topics
 
-- [Storage Patterns](../concepts/storage.md)
-- [Designing Custom Types](./custom-types.mdx)
-- [Security Fundamentals](../security/fundamentals.md)
+- [Gas and Resource Management](/docs/concepts/gas-and-resources) — cost drivers this playbook optimizes
+- [Storage Patterns](/docs/concepts/storage)
+- [Designing Custom Types](/docs/patterns/custom-types)
+- [Security Fundamentals](/docs/security/fundamentals)

--- a/documentation/docs/patterns/overview.md
+++ b/documentation/docs/patterns/overview.md
@@ -1,10 +1,8 @@
 ---
-title: Pattern library
+title: Pattern Library
 description: Reusable Soroban smart contract patterns — storage, tokens, DeFi, and more.
 image: /img/soroban-social-card.png
 ---
-
-# Pattern Library
 
 Reusable smart contract patterns for common use cases.
 
@@ -44,6 +42,8 @@ Comprehensive error handling patterns including Result types, fallback logic, gr
 - Token wrappers and vaults
 - Multi-token systems
 
+See [Token Pattern Security Audit](/docs/security/token-audit) for per-pattern audit checklists before deploying token contracts.
+
 ### 💰 DeFi Patterns
 
 <span class="sb-tag sb-tag--defi">DeFi</span>
@@ -81,7 +81,7 @@ Each pattern includes:
 
 ## Contributing
 
-Have a pattern to share? See our [Contributing Guide](https://github.com/Soroban-Cookbook/Soroban-Cookbook-/blob/main/CONTRIBUTING.md).
+Have a pattern to share? See our [Contributing Guide](https://github.com/Soroban-Cookbook/Soroban_Cookbook_online/blob/main/CONTRIBUTING.md).
 
 ## Getting Started
 
@@ -94,5 +94,8 @@ Start exploring:
 
 ## Resources
 
+- [Error Handling pattern](/docs/patterns/error-handling) — error taxonomy for production contracts
+- [Hello World Storage](/docs/patterns/hello-world) — pattern page template
+- [Security Fundamentals](/docs/security/fundamentals) — review before mainnet
 - [Soroban Examples](https://github.com/stellar/soroban-examples)
-- [Community Patterns](https://github.com/Soroban-Cookbook/Soroban-Cookbook-)
+- [Community Patterns](https://github.com/Soroban-Cookbook/Soroban_Cookbook_online)

--- a/documentation/docs/patterns/proposal-lifecycle.mdx
+++ b/documentation/docs/patterns/proposal-lifecycle.mdx
@@ -251,6 +251,7 @@ Add `require_auth()` guards on every privileged transition before deploying to m
 <PatternSection id="related" title="Related patterns">
 
 - [Authorization & Access Control](/docs/patterns/authorization) — guard transitions with `require_auth`
+- [Governance Security](/docs/security/governance) — voting and timelock hardening
 - [Lifecycle & Upgrades](/docs/patterns/lifecycle-upgrades) — contract upgrade patterns
 - [Pattern library overview](/docs/patterns/overview)
 

--- a/documentation/docs/responsive/breakpoints.mdx
+++ b/documentation/docs/responsive/breakpoints.mdx
@@ -4,8 +4,6 @@ title: Responsive Breakpoint System
 description: Mobile-first responsive design guidelines, breakpoint tokens, container system, and utility classes for the Soroban Cookbook.
 ---
 
-# Responsive Breakpoint System
-
 The Soroban Cookbook uses a **mobile-first** responsive design approach. Styles are written for the smallest screen first, then progressively enhanced for larger screens using `min-width` media queries.
 
 :::info Import Required
@@ -416,3 +414,11 @@ Before submitting a PR with responsive changes, verify the following:
 - [ ] Tested with keyboard navigation
 - [ ] Tested with OS "Reduce Motion" enabled
 - [ ] `hide-*` / `show-*` utilities work as expected
+
+---
+
+## Related links
+
+- [Typography System](/docs/design-system/typography) — responsive type utilities
+- [Button System](/docs/design-system/buttons) — touch-target sizing on mobile
+- [Internal Linking Strategy](/docs/contributing/internal-linking) — doc structure conventions

--- a/documentation/docs/security/fundamentals.md
+++ b/documentation/docs/security/fundamentals.md
@@ -3,8 +3,6 @@ title: Security Fundamentals
 sidebar_position: 1
 ---
 
-# Security Fundamentals
-
 Building on Stellar requires a security-first mindset. Unlike traditional web applications, smart contract vulnerabilities often lead to immediate and irreversible loss of funds.
 
 This guide provides a practical foundation for securing your Soroban smart contracts.
@@ -107,6 +105,8 @@ Use this checklist before every deployment:
 - [ ] **Events:** Sensitive operations (admin changes, large transfers) emit descriptive events.
 - [ ] **Error Handling:** Errors are explicit (using `Result` and custom error enums).
 
+For token contracts (mint, transfer, allowances, vaults, wrappers), complete the dedicated [Token Pattern Security Audit](/docs/security/token-audit) checklist before deployment.
+
 ---
 
 ## 4. Secure Development Workflow
@@ -117,3 +117,12 @@ Use this checklist before every deployment:
 4.  **Integration Testing:** Test interactions between multiple contracts.
 5.  **Self-Audit:** Review code against the [Mitigation Checklist](#3-mitigation-checklist).
 6.  **Peer Review:** Have another developer review the logic and security assumptions.
+
+---
+
+## Related links
+
+- [Authorization](/docs/concepts/authorization) — access control patterns for sensitive functions
+- [Token Pattern Security Audit](/docs/security/token-audit) — token-specific audit checklist
+- [Governance Security](/docs/security/governance) — voting and timelock risks
+- [Cross-Contract Invocation](/docs/concepts/cross-contract-invocation) — safe external call patterns

--- a/documentation/docs/security/governance.md
+++ b/documentation/docs/security/governance.md
@@ -3,8 +3,6 @@ title: Governance Security
 sidebar_position: 2
 ---
 
-# Governance Security
-
 Governance systems enable decentralized decision-making, but they introduce unique attack vectors that must be carefully mitigated. This guide covers critical security considerations for Soroban governance contracts.
 
 ---
@@ -29,7 +27,7 @@ A typical governance system includes:
 
 **Mitigation Strategies:**
 - **Time-Locked Voting Power:** Require tokens to be locked for a minimum period (e.g., 7 days) before they can be used to vote.
-- **Snapshot-Based Voting:** Use historical balances (snapshots) instead of current balances to determine voting power.
+- **Snapshot-Based Voting:** Use historical balances (snapshots) instead of current balances to determine voting power. See [Token Pattern Security Audit — Snapshots](/docs/security/token-audit#29-snapshot-balances-governance--dividends) for snapshot hardening.
 - **Voting Delay:** Add a delay between proposal creation and the start of voting to give stakeholders time to react.
 - **Staking-Based Voting:** Only allow staked tokens (with unstaking delays) to vote.
 
@@ -90,3 +88,11 @@ Use a separate timelock contract that queues and executes proposals after a dela
 
 ### Pattern 3: Multi-Sig + Timelock
 Combine a multi-signature wallet with a timelock for critical governance actions.
+
+---
+
+## Related links
+
+- [Security Fundamentals](/docs/security/fundamentals) — general contract security baseline
+- [Proposal Lifecycle pattern](/docs/patterns/proposal-lifecycle) — DAO state machine example
+- [Token Pattern Security Audit](/docs/security/token-audit) — snapshot and voting-power hardening

--- a/documentation/docs/security/token-audit.md
+++ b/documentation/docs/security/token-audit.md
@@ -1,0 +1,389 @@
+---
+title: Token Pattern Security Audit
+description: Security considerations and audit checklists for Soroban token patterns — basic tokens, allowances, wrappers, vaults, vesting, and SAC integration.
+sidebar_position: 3
+---
+
+Token contracts hold or move value directly. A single logic flaw can drain balances or inflate supply irreversibly. Use this guide alongside [Security Fundamentals](/docs/security/fundamentals) when designing, reviewing, or deploying any token-related pattern.
+
+The checklists below map to the token patterns catalogued in the [Pattern Library](/docs/patterns/overview#-token-standards) and the [`examples/token-transfer/`](https://github.com/Soroban-Cookbook/Soroban_Cookbook_online/tree/main/examples/token-transfer) reference implementation.
+
+---
+
+## 1. Token Threat Model
+
+### Assets at risk
+
+- **User balances** — persistent storage keyed by `Address`.
+- **Total supply** — mint/burn authority and supply accounting.
+- **Allowances** — delegated spending rights between owner and spender.
+- **Vault deposits** — tokens held by wrapper, vault, or escrow contracts on behalf of users.
+- **Metadata integrity** — name, symbol, decimals, and issuer fields that wallets and indexers trust.
+
+### Common attack goals
+
+| Goal | Typical exploit |
+|------|-----------------|
+| Steal tokens | Missing `require_auth`, flawed allowance logic, reentrancy via cross-contract calls |
+| Mint unbounded supply | Unprotected `mint`, admin key compromise, upgrade hijack |
+| Lock funds permanently | Pausable flag stuck, vault accounting desync, vesting schedule bugs |
+| Manipulate integrations | Wrong decimals, balance snapshot timing, fake token contract address |
+
+### Soroban-specific context
+
+- **Atomic transactions** — state rolls back on panic, but cross-contract calls in the same transaction still share one budget and one atomic boundary.
+- **No EVM-style reentrancy by default** — still follow **Checks-Effects-Interactions** when calling external token contracts from vaults or wrappers.
+- **Persistent storage costs** — unbounded allowance maps or balance iteration can create DoS via resource exhaustion.
+- **Prefer SAC when possible** — the [Stellar Asset Contract (SAC)](https://developers.stellar.org/docs/tokens/stellar-asset-contract) is audited, SEP-41 compatible, and interoperable with the Stellar ecosystem. Custom tokens add implementation risk.
+
+---
+
+## 2. Pattern-Specific Risks & Mitigations
+
+### 2.1 Basic token (mint / transfer / balance)
+
+Reference: [`examples/token-transfer/src/lib.rs`](https://github.com/Soroban-Cookbook/Soroban_Cookbook_online/blob/main/examples/token-transfer/src/lib.rs)
+
+**High-risk areas**
+
+- **Unprotected mint** — any caller can inflate supply if `mint` lacks admin auth.
+- **Transfer without auth** — debiting `from` without `from.require_auth()` lets anyone move others' tokens.
+- **Unchecked arithmetic** — balance updates must use `checked_add` / `checked_sub` or equivalent safe math.
+- **Invalid amounts** — zero or negative transfers should fail explicitly.
+- **Self-transfer edge cases** — decide whether self-transfers are allowed; document and test the choice.
+
+**Mitigations**
+
+```rust
+// ✅ Transfer: authorize debited account
+pub fn transfer(env: Env, from: Address, to: Address, amount: i128) -> Result<(), Error> {
+    from.require_auth();
+    if amount <= 0 { return Err(Error::InvalidAmount); }
+    // ... checked balance updates
+    Ok(())
+}
+
+// ✅ Mint: restrict to admin
+pub fn mint(env: Env, admin: Address, to: Address, amount: i128) -> Result<(), Error> {
+    admin.require_auth();
+    Self::require_admin(&env, &admin)?;
+    // ... checked supply and balance updates
+    Ok(())
+}
+```
+
+**Audit focus**
+
+- [ ] Every balance-decreasing path calls `require_auth` on the debited account (or valid allowance — see §2.4).
+- [ ] Mint and burn are gated to explicit roles, not public.
+- [ ] Amount validation rejects `<= 0` and overflow paths.
+- [ ] Events emitted for mint, burn, and transfer (for indexers and incident response).
+
+---
+
+### 2.2 Token metadata (name, symbol, decimals, total supply)
+
+**High-risk areas**
+
+- **Decimals mismatch** — integrators assume 7 decimals (Stellar default) or your declared value; wrong decimals cause 10× accounting errors.
+- **Mutable metadata post-deploy** — changing symbol or decimals breaks wallet caches and user trust.
+- **Supply desync** — stored `total_supply` diverges from sum of balances after buggy mint/burn.
+
+**Mitigations**
+
+- Set metadata once at initialization; make fields immutable or admin-only with timelock.
+- Expose `decimals()` consistently; document rounding rules for UI integrators.
+- Reconcile `total_supply` in tests after every mint/burn sequence.
+
+**Audit focus**
+
+- [ ] Metadata initialized before any mint and not silently mutable.
+- [ ] `total_supply` matches mint/burn accounting in property tests.
+- [ ] Decimals documented in deployment guide and on-chain.
+
+---
+
+### 2.3 Token burn
+
+**High-risk areas**
+
+- **Burning others' tokens** without authorization.
+- **Supply underflow** — burning more than balance or more than outstanding supply.
+- **Missing events** — burned tokens invisible to off-chain accounting.
+
+**Mitigations**
+
+```rust
+pub fn burn(env: Env, from: Address, amount: i128) -> Result<(), Error> {
+    from.require_auth();
+    if amount <= 0 { return Err(Error::InvalidAmount); }
+    let balance = get_balance(&env, &from);
+    let new_balance = balance.checked_sub(amount).ok_or(Error::InsufficientBalance)?;
+    set_balance(&env, &from, new_balance);
+    decrease_total_supply(&env, amount)?;
+    env.events().publish(("burn", from), amount);
+    Ok(())
+}
+```
+
+**Audit focus**
+
+- [ ] `from.require_auth()` on all burn paths.
+- [ ] Total supply decreases atomically with balance.
+- [ ] Burn events include account and amount.
+
+---
+
+### 2.4 Token allowance (approve / transfer_from)
+
+**High-risk areas**
+
+- **Allowance not decremented** — spender can drain repeatedly.
+- **Race / double-spend** — multiple `transfer_from` in one transaction exceeding allowance (mitigated by atomic txs, but logic must still check remaining allowance).
+- **Infinite approval footgun** — `i128::MAX` approvals are convenient but irreversible until revoked.
+- **Spender auth confusion** — debiting owner without validating spender identity or allowance.
+
+**Mitigations**
+
+```rust
+pub fn transfer_from(
+    env: Env,
+    spender: Address,
+    from: Address,
+    to: Address,
+    amount: i128,
+) -> Result<(), Error> {
+    spender.require_auth();
+    let allowance = get_allowance(&env, &from, &spender);
+    if allowance < amount { return Err(Error::InsufficientAllowance); }
+    set_allowance(&env, &from, &spender, allowance - amount);
+    // ... debit from, credit to (same checks as transfer)
+    Ok(())
+}
+```
+
+**Audit focus**
+
+- [ ] Allowance reduced before or atomically with balance move (Checks-Effects-Interactions).
+- [ ] `approve` requires owner auth; zeroing allowance supported for revocation.
+- [ ] Tests cover partial spend, full spend, over-spend revert, and approval overwrite.
+
+---
+
+### 2.5 Token wrapper
+
+Wrappers add logic around an underlying token (fees, logging, compliance hooks, upgrade surface).
+
+**High-risk areas**
+
+- **Fee-on-transfer desync** — wrapper and underlying balances diverge when fees are skimmed incorrectly.
+- **Wrong underlying address** — pointing at attacker-controlled contract.
+- **Reentrancy via callback** — external token call before internal accounting update.
+- **Upgradeable wrapper** — malicious upgrade replaces fee recipient or disables withdrawals.
+
+**Mitigations**
+
+- Store underlying token address in instance storage; validate interface at init.
+- Update wrapper ledger **before** calling external `transfer`.
+- Cap fees with hardcoded maximum basis points; emit fee events.
+- If upgradeable, apply [Lifecycle & Upgrade Safety](/docs/patterns/lifecycle-upgrades) controls.
+
+**Audit focus**
+
+- [ ] Underlying token ID validated at initialization and not user-supplied per call.
+- [ ] Fee math uses checked arithmetic and documented rounding.
+- [ ] Deposit and withdraw paths tested against malicious underlying (mock that re-enters).
+- [ ] Users can always redeem underlying (no stuck wrapper shares).
+
+---
+
+### 2.6 Multi-token vault
+
+Vaults hold multiple asset types and track per-user shares or per-asset balances.
+
+**High-risk areas**
+
+- **Share inflation attack** — first depositor griefing via donation + share manipulation.
+- **Cross-asset accounting errors** — withdrawing asset A while credited for asset B.
+- **Oracle / price trust** — if vault values positions by external price, stale or manipulated prices drain funds.
+- **Token ID confusion** — same interface, different contract addresses.
+
+**Mitigations**
+
+- Use minimum initial deposit or dead shares on first deposit to mitigate inflation attacks.
+- Namespace storage by `(token_id, user)`; never mix asset keys.
+- Validate `token_id` against an allowlist set by admin.
+- Follow [Cross-Contract Invocation](/docs/concepts/cross-contract-invocation) defensive patterns.
+
+**Audit focus**
+
+- [ ] Per-asset balance isolation verified in tests.
+- [ ] First-depositor / empty-vault edge cases covered.
+- [ ] Withdraw always ≤ deposited + earned (no over-withdrawal paths).
+- [ ] Allowlist or registry for supported tokens.
+
+---
+
+### 2.7 Token vesting & timelock
+
+**High-risk areas**
+
+- **Premature unlock** — timestamp comparison off-by-one or wrong ledger time source.
+- **Admin clawback** — beneficiary expects irrevocable vesting; hidden admin keys undermine trust.
+- **Partial release desync** — released amount exceeds vested amount.
+
+**Mitigations**
+
+- Use `env.ledger().timestamp()` consistently; document timezone-agnostic semantics.
+- Make schedules immutable or governance-controlled with timelock.
+- Store `released` and `vested` separately; assert `released <= vested` on every claim.
+
+**Audit focus**
+
+- [ ] Claims revert before cliff and after full release.
+- [ ] No path releases more than schedule allows.
+- [ ] Admin powers explicit and documented for users.
+
+---
+
+### 2.8 Snapshot balances (governance / dividends)
+
+**High-risk areas**
+
+- **Flash-loan snapshot manipulation** — balance recorded at block that attacker temporarily inflates.
+- **Double-claim** — same snapshot used twice for rewards or votes.
+
+**Mitigations**
+
+- Snapshot at `ledger_sequence - N` or require tokens locked in staking contract.
+- Mark claims consumed per `(snapshot_id, account)`.
+- See [Governance Security](/docs/security/governance) for voting-specific guidance.
+
+**Audit focus**
+
+- [ ] Snapshot timing resistant to single-block balance spikes.
+- [ ] One claim per snapshot per address enforced on-chain.
+
+---
+
+### 2.9 Pausable token
+
+**High-risk areas**
+
+- **Pause stuck on** — admin compromise or missing unpause permanently freezes transfers.
+- **Pause bypass** — mint/burn/transfer_from not all guarded by pause flag.
+- **Centralization risk** — users unaware single key can halt market.
+
+**Mitigations**
+
+- Guard **all** value-moving functions: `transfer`, `transfer_from`, `mint`, `burn`.
+- Emit `Paused` / `Unpaused` events; consider timelock on pause for production.
+- Document centralization tradeoff in deployment materials.
+
+**Audit focus**
+
+- [ ] Pause flag checked on every mutating entry point (grep for uncovered paths).
+- [ ] Unpause requires same or higher authority as pause.
+- [ ] View functions (`balance`, `allowance`) still work while paused.
+
+---
+
+### 2.10 Stellar Asset Contract (SAC) integration
+
+When wrapping or interacting with SAC instead of a custom token:
+
+**High-risk areas**
+
+- **Wrong asset / contract address** — user deposits to vault wired to testnet SAC on mainnet.
+- **Trustline assumptions** — Stellar classic assets require trustlines; Soroban SAC behavior differs from custom contracts.
+- **Assuming EVM ERC-20 semantics** — SEP-41 interface differs; read Stellar docs before porting patterns.
+
+**Mitigations**
+
+- Pin SAC contract IDs in storage; verify on deploy with CLI / explorer.
+- Use SDK-generated `token::Client` for typed calls.
+- Prefer SAC issuance for fungible assets unless custom logic is required.
+
+**Audit focus**
+
+- [ ] Callee addresses match intended network and asset.
+- [ ] Integration tests run against SAC testnet deployment.
+- [ ] Custom logic documented where it diverges from SAC defaults.
+
+---
+
+## 3. Master Token Security Audit Checklist
+
+Complete this checklist before mainnet deployment. Items apply to **all** token patterns unless marked optional.
+
+### Authorization & access control
+
+- [ ] All transfer, mint, burn, and allowance mutations call `require_auth` on the correct identity.
+- [ ] Admin / minter / pauser roles stored in instance storage and protected.
+- [ ] No public function can move tokens without explicit user or allowance consent.
+
+### Arithmetic & invariants
+
+- [ ] All balance and supply math uses checked operations.
+- [ ] `sum(balances) <= total_supply` (or `==` if no unallocated supply) holds after every operation.
+- [ ] Allowances never negative; transfers never exceed balance or allowance.
+
+### Storage & DoS
+
+- [ ] Balance and allowance keys scoped by `Address` (no unbounded iteration over user sets in a single call).
+- [ ] Persistent storage growth is predictable and budget-tested.
+
+### Cross-contract & composition
+
+- [ ] External token calls happen **after** internal state updates (Checks-Effects-Interactions).
+- [ ] Token contract addresses come from trusted storage, not unvalidated user input.
+- [ ] Failure modes from external token calls handled (return `Result`, don't assume success).
+
+### Observability
+
+- [ ] Mint, burn, transfer, approve, pause, and admin changes emit structured events.
+- [ ] Error enums are explicit (no silent `unwrap` on user paths).
+
+### Testing
+
+- [ ] Unauthorized transfer / mint / burn revert.
+- [ ] Zero and negative amounts revert.
+- [ ] Insufficient balance and allowance revert with state unchanged.
+- [ ] Property or fuzz tests for supply conservation (where feasible).
+- [ ] Cross-contract tests for vault / wrapper paths with mock re-entering token.
+
+### Operational & governance
+
+- [ ] Upgrade path reviewed if contract is upgradeable ([Lifecycle guide](/docs/patterns/lifecycle-upgrades)).
+- [ ] Centralization risks (pause, mint, admin) documented for users.
+- [ ] Incident response: how to pause, rotate admin, and communicate on-chain events.
+
+---
+
+## 4. Pattern Quick-Reference Matrix
+
+Use this matrix during review to ensure pattern-specific items are not missed.
+
+| Pattern | Critical checks |
+|---------|-----------------|
+| Basic token | Auth on transfer; gated mint; amount validation |
+| Metadata | Immutable fields; decimals documented; supply sync |
+| Burn | Auth on burn; supply decrease; events |
+| Allowance | Decrement on spend; owner auth on approve |
+| Wrapper | CEI ordering; fee caps; underlying address trust |
+| Multi-token vault | Asset isolation; first-depositor; allowlist |
+| Vesting / timelock | Timestamp source; no over-release |
+| Snapshot | Flash-loan resistance; one claim per snapshot |
+| Pausable | All mutators guarded; unpause auth |
+| SAC integration | Correct contract ID; SEP-41 semantics |
+
+---
+
+## 5. Related Resources
+
+- [Security Fundamentals](/docs/security/fundamentals) — general contract security baseline
+- [Authorization concepts](/docs/concepts/authorization) — access control patterns
+- [Cross-Contract Invocation](/docs/concepts/cross-contract-invocation) — safe external token calls
+- [Governance Security](/docs/security/governance) — token-weighted voting risks
+- [Pattern Library — Token Standards](/docs/patterns/overview#-token-standards) — pattern catalog
+- [Stellar token documentation](https://developers.stellar.org/docs/tokens/stellar-asset-contract) — SAC and SEP-41 reference

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -230,7 +230,7 @@ const config: Config = {
           items: [
             {
               label: 'Soroban Docs',
-              href: 'https://developers.stellar.org/docs/smart-contracts',
+              href: 'https://developers.stellar.org/docs/build/smart-contracts',
             },
             {
               label: 'GitHub',

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -18,6 +18,9 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,css,json,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css,json,md}\"",
     "format:write": "prettier --write \"src/**/*.{ts,tsx,css,json,md}\"",
+    "audit:headings": "node scripts/audit-heading-hierarchy.mjs",
+    "audit:links": "node scripts/audit-internal-links.mjs",
+    "check:external-links": "node scripts/check-external-links.mjs",
     "test:e2e": "playwright test",
     "test:console": "playwright test e2e/smoke-console.spec.ts"
   },

--- a/documentation/scripts/audit-heading-hierarchy.mjs
+++ b/documentation/scripts/audit-heading-hierarchy.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Audits markdown/MDX docs for H1–H6 heading hierarchy issues.
+ * Docusaurus renders frontmatter `title` as an implicit H1.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const docRoots = [
+  path.join(__dirname, '../docs'),
+  path.join(__dirname, '../src/pages'),
+];
+
+function walk(dir, files = []) {
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, ent.name);
+    if (ent.isDirectory() && ent.name !== 'node_modules') walk(p, files);
+    else if (/\.(md|mdx)$/.test(ent.name)) files.push(p);
+  }
+  return files;
+}
+
+function parseHeadings(content) {
+  const lines = content.split(/\r?\n/);
+  const headings = [];
+  let inCode = false;
+  let fmTitle = null;
+
+  if (lines[0]?.trim() === '---') {
+    let i = 1;
+    while (i < lines.length && lines[i].trim() !== '---') {
+      const m = lines[i].match(/^title:\s*(.+)$/);
+      if (m) fmTitle = m[1].replace(/^['"]|['"]$/g, '').trim();
+      i++;
+    }
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim().startsWith('```')) {
+      inCode = !inCode;
+      continue;
+    }
+    if (inCode) continue;
+    const m = line.match(/^(#{1,6})\s+(.+)$/);
+    if (m) headings.push({ level: m[1].length, text: m[2].trim(), line: i + 1 });
+  }
+
+  return { headings, fmTitle };
+}
+
+function auditFile(file) {
+  const rel = path.relative(path.join(__dirname, '..'), file).replace(/\\/g, '/');
+  const content = fs.readFileSync(file, 'utf8');
+  const { headings, fmTitle } = parseHeadings(content);
+  const h1s = headings.filter((h) => h.level === 1);
+  const issues = [];
+
+  const effectiveH1 = (fmTitle ? 1 : 0) + h1s.length;
+  if (effectiveH1 === 0) {
+    issues.push({ type: 'missing-h1', detail: 'No frontmatter title and no # heading' });
+  }
+  if (effectiveH1 > 1) {
+    issues.push({
+      type: 'multiple-h1',
+      detail: `frontmatter title: ${Boolean(fmTitle)}, markdown H1 count: ${h1s.length}`,
+      h1Lines: h1s.map((h) => h.line),
+    });
+  }
+
+  if (headings.length && fmTitle && headings[0].level === 1) {
+    issues.push({
+      type: 'duplicate-h1',
+      detail: `Remove markdown H1 "${headings[0].text}" — frontmatter title "${fmTitle}" is already H1`,
+      line: headings[0].line,
+    });
+  }
+
+  if (headings.length && !fmTitle && h1s.length === 0 && headings[0].level > 1) {
+    issues.push({
+      type: 'starts-without-h1',
+      detail: `First heading is H${headings[0].level}: "${headings[0].text}"`,
+      line: headings[0].line,
+    });
+  }
+
+  const tree = [];
+  if (fmTitle) tree.push({ level: 1, text: fmTitle, line: 0 });
+  for (const h of headings) tree.push(h);
+
+  for (let i = 1; i < tree.length; i++) {
+    const prev = tree[i - 1].level;
+    const curr = tree[i].level;
+    if (curr > prev + 1) {
+      issues.push({
+        type: 'skip-level',
+        detail: `H${prev} "${tree[i - 1].text}" → H${curr} "${tree[i].text}"`,
+        line: tree[i].line,
+      });
+    }
+  }
+
+  return issues.length ? { file: rel, issues } : null;
+}
+
+const results = [];
+for (const root of docRoots) {
+  if (!fs.existsSync(root)) continue;
+  for (const file of walk(root)) {
+    const result = auditFile(file);
+    if (result) results.push(result);
+  }
+}
+
+const byType = {};
+for (const r of results) {
+  for (const issue of r.issues) {
+    byType[issue.type] = (byType[issue.type] || 0) + 1;
+  }
+}
+
+console.log('Heading hierarchy audit\n');
+console.log('Summary by issue type:');
+for (const [type, count] of Object.entries(byType).sort()) {
+  console.log(`  ${type}: ${count}`);
+}
+console.log(`\nFiles with issues: ${results.length}\n`);
+
+for (const r of results.sort((a, b) => a.file.localeCompare(b.file))) {
+  console.log(`${r.file}`);
+  for (const issue of r.issues) {
+    const loc = issue.line ? ` (line ${issue.line})` : '';
+    console.log(`  [${issue.type}]${loc} ${issue.detail}`);
+  }
+  console.log('');
+}
+
+process.exit(results.length > 0 ? 1 : 0);

--- a/documentation/scripts/audit-internal-links.mjs
+++ b/documentation/scripts/audit-internal-links.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Audits documentation internal links against link-registry.json.
+ * Validates required cross-links, minimum internal link counts, and orphans.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const docsRoot = path.join(__dirname, '../docs');
+const registryPath = path.join(__dirname, 'link-registry.json');
+
+function walk(dir, files = []) {
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, ent.name);
+    if (ent.isDirectory() && ent.name !== 'node_modules') walk(p, files);
+    else if (/\.(md|mdx)$/.test(ent.name)) files.push(p);
+  }
+  return files;
+}
+
+function docIdFromPath(filePath) {
+  const rel = path.relative(docsRoot, filePath).replace(/\\/g, '/');
+  if (rel === 'index.md') return 'index';
+  return rel.replace(/\.(md|mdx)$/, '');
+}
+
+function normalizeTarget(raw, sourceId) {
+  let target = raw.trim();
+  if (target.startsWith('http') || target.startsWith('#') || target.startsWith('mailto:')) {
+    return null;
+  }
+  target = target.split('#')[0].split('?')[0];
+  if (!target) return null;
+
+  if (target.startsWith('/docs/')) {
+    return target
+      .replace(/\/$/, '')
+      .replace(/\.(md|mdx)$/, '') || '/docs';
+  }
+  if (target.startsWith('/')) return null;
+
+  const sourceDir = sourceId.includes('/') ? sourceId.replace(/\/[^/]+$/, '') : '';
+  let resolved = target;
+  if (target.startsWith('./') || target.startsWith('../') || !target.startsWith('/')) {
+    const baseParts = sourceDir ? sourceDir.split('/') : [];
+    const relParts = target.split('/');
+    for (const part of relParts) {
+      if (part === '.' || part === '') continue;
+      if (part === '..') baseParts.pop();
+      else baseParts.push(part);
+    }
+    resolved = baseParts.join('/');
+  }
+  resolved = resolved.replace(/\.(md|mdx)$/, '');
+  return `/docs/${resolved}`;
+}
+
+function extractInternalLinks(content, sourceId) {
+  const links = new Set();
+  const mdLink = /\[([^\]]*)\]\(([^)]+)\)/g;
+  let m;
+  while ((m = mdLink.exec(content)) !== null) {
+    const normalized = normalizeTarget(m[2], sourceId);
+    if (normalized) links.add(normalized);
+  }
+  return links;
+}
+
+function resolveDocFile(docPath) {
+  const candidates = [
+    path.join(docsRoot, `${docPath}.md`),
+    path.join(docsRoot, `${docPath}.mdx`),
+    path.join(docsRoot, docPath, 'index.md'),
+  ];
+  if (docPath === 'index' || docPath === '/docs' || docPath === '/docs/') {
+    return path.join(docsRoot, 'index.md');
+  }
+  const slug = docPath.replace(/^\/docs\//, '');
+  candidates.unshift(
+    path.join(docsRoot, `${slug}.md`),
+    path.join(docsRoot, `${slug}.mdx`),
+  );
+  return candidates.find((p) => fs.existsSync(p)) ?? null;
+}
+
+const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+const allFiles = walk(docsRoot);
+const issues = [];
+const inbound = new Map();
+
+for (const file of allFiles) {
+  const id = docIdFromPath(file);
+  const content = fs.readFileSync(file, 'utf8');
+  const links = extractInternalLinks(content, id);
+  for (const link of links) {
+    const key = link.replace(/^\/docs\//, '').replace(/\/$/, '') || 'index';
+    inbound.set(key, (inbound.get(key) ?? 0) + 1);
+  }
+}
+
+for (const [id, rules] of Object.entries(registry.pages)) {
+  const file =
+    id === 'index'
+      ? path.join(docsRoot, 'index.md')
+      : resolveDocFile(id);
+  if (!file) {
+    issues.push({ id, type: 'missing-file', detail: 'Registry page has no doc file' });
+    continue;
+  }
+
+  const content = fs.readFileSync(file, 'utf8');
+  const links = extractInternalLinks(content, id);
+
+  for (const required of rules.requiredLinks ?? []) {
+    const normalized = required.replace(/\/$/, '');
+    const found = [...links].some(
+      (l) => l === normalized || l === `${normalized}/`,
+    );
+    if (!found) {
+      issues.push({
+        id,
+        type: 'missing-required-link',
+        detail: `Missing required link to ${required}`,
+      });
+    }
+  }
+
+  const min = rules.minInternalLinks ?? 2;
+  if (links.size < min) {
+    issues.push({
+      id,
+      type: 'insufficient-links',
+      detail: `Found ${links.size} internal link(s), need at least ${min}`,
+    });
+  }
+}
+
+for (const [id] of Object.entries(registry.pages)) {
+  const key = id === 'index' ? 'index' : id;
+  if ((inbound.get(key) ?? 0) === 0 && id !== 'index') {
+    // Advisory only — sidebar navigation also provides discoverability
+    console.warn(`[advisory] ${id}: no inbound markdown links`);
+  }
+}
+
+const blockingIssues = issues.filter((i) => i.type !== 'orphan');
+
+const byType = {};
+for (const issue of blockingIssues) {
+  byType[issue.type] = (byType[issue.type] ?? 0) + 1;
+}
+
+console.log('Internal link audit\n');
+console.log('Summary by issue type:');
+for (const [type, count] of Object.entries(byType).sort()) {
+  console.log(`  ${type}: ${count}`);
+}
+console.log(`\nPages checked: ${Object.keys(registry.pages).length}`);
+console.log(`Issues: ${blockingIssues.length}\n`);
+
+for (const issue of blockingIssues.sort((a, b) => a.id.localeCompare(b.id))) {
+  console.log(`${issue.id}`);
+  console.log(`  [${issue.type}] ${issue.detail}`);
+}
+
+process.exit(blockingIssues.length > 0 ? 1 : 0);

--- a/documentation/scripts/check-external-links.mjs
+++ b/documentation/scripts/check-external-links.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Checks external (https/http) links in docs and site source.
+ * Complements Docusaurus onBrokenLinks which only validates internal routes at build.
+ *
+ * Usage: node scripts/check-external-links.mjs
+ * Env:
+ *   EXTERNAL_LINK_TIMEOUT_MS — per-request timeout (default 15000)
+ *   EXTERNAL_LINK_CONCURRENCY — parallel checks (default 8)
+ *   EXTERNAL_LINK_REPORT — report path relative to documentation/ (default reports/external-links.md)
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const docRoot = path.join(__dirname, '..');
+const docsDir = path.join(docRoot, 'docs');
+const srcDir = path.join(docRoot, 'src');
+const ignorePath = path.join(__dirname, 'external-link-ignore.json');
+const reportRel =
+  process.env.EXTERNAL_LINK_REPORT ?? 'reports/external-links.md';
+const reportPath = path.join(docRoot, reportRel);
+const timeoutMs = Number(process.env.EXTERNAL_LINK_TIMEOUT_MS ?? 15000);
+const concurrency = Number(process.env.EXTERNAL_LINK_CONCURRENCY ?? 8);
+const userAgent = 'Soroban-Cookbook-LinkChecker/1.0 (+https://soroban-cookbook.dev)';
+
+const scanRoots = [
+  { dir: docsDir, exts: ['.md', '.mdx'] },
+  { dir: srcDir, exts: ['.tsx', '.ts', '.jsx', '.js', '.md', '.mdx'] },
+];
+
+const skipDirs = new Set(['node_modules', 'build', '.docusaurus', '__tests__']);
+
+function walk(dir, exts, files = []) {
+  if (!fs.existsSync(dir)) return files;
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (skipDirs.has(ent.name)) continue;
+    const p = path.join(dir, ent.name);
+    if (ent.isDirectory()) walk(p, exts, files);
+    else if (exts.some((e) => ent.name.endsWith(e))) files.push(p);
+  }
+  return files;
+}
+
+function stripTrailingPunctuation(url) {
+  return url.replace(/[),.;:!?\]]+$/, '');
+}
+
+function isCheckableUrl(url) {
+  if (url.includes('[') || url.includes('<')) return false;
+  return true;
+}
+
+function extractExternalUrls(content) {
+  const urls = new Set();
+  const patterns = [
+    /\[[^\]]*\]\((https?:\/\/[^)\s]+)\)/g,
+    /href=["'](https?:\/\/[^"']+)["']/g,
+    /(?:^|\s)(https?:\/\/[^\s<>"')\]`]+)/g,
+  ];
+  for (const pattern of patterns) {
+    let m;
+    while ((m = pattern.exec(content)) !== null) {
+      const normalized = stripTrailingPunctuation(m[1]);
+      if (isCheckableUrl(normalized)) urls.add(normalized);
+    }
+  }
+  return urls;
+}
+
+function loadIgnoreRules() {
+  const rules = JSON.parse(fs.readFileSync(ignorePath, 'utf8'));
+  return {
+    hostPatterns: (rules.hostPatterns ?? []).map((p) => new RegExp(p, 'i')),
+    urlPatterns: (rules.urlPatterns ?? []).map((p) => new RegExp(p, 'i')),
+    urls: new Set(rules.urls ?? []),
+  };
+}
+
+function shouldIgnore(url, ignore) {
+  if (ignore.urls.has(url)) return true;
+  for (const p of ignore.urlPatterns) {
+    if (p.test(url)) return true;
+  }
+  try {
+    const host = new URL(url).hostname;
+    for (const p of ignore.hostPatterns) {
+      if (p.test(host)) return true;
+    }
+  } catch {
+    return true;
+  }
+  return false;
+}
+
+async function checkUrlOnce(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const headers = { 'User-Agent': userAgent, Accept: '*/*' };
+
+  try {
+    let response = await fetch(url, {
+      method: 'HEAD',
+      redirect: 'follow',
+      signal: controller.signal,
+      headers,
+    });
+
+    if ([403, 404, 405, 501].includes(response.status)) {
+      response = await fetch(url, {
+        method: 'GET',
+        redirect: 'follow',
+        signal: controller.signal,
+        headers: { ...headers, Range: 'bytes=0-0' },
+      });
+    }
+
+    if ([403, 404, 405, 501].includes(response.status)) {
+      response = await fetch(url, {
+        method: 'GET',
+        redirect: 'follow',
+        signal: controller.signal,
+        headers,
+      });
+    }
+
+    const ok = response.ok || (response.status >= 300 && response.status < 400);
+    return { ok, status: response.status, finalUrl: response.url };
+  } catch (error) {
+    const message =
+      error.name === 'AbortError' ? `Timeout after ${timeoutMs}ms` : error.message;
+    return { ok: false, status: 0, error: message };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function checkUrl(url) {
+  let last = await checkUrlOnce(url);
+  if (last.ok) return last;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    last = await checkUrlOnce(url);
+    if (last.ok) return last;
+  }
+
+  return last;
+}
+
+async function mapPool(items, limit, fn) {
+  const results = new Array(items.length);
+  let index = 0;
+
+  async function worker() {
+    while (index < items.length) {
+      const i = index++;
+      results[i] = await fn(items[i], i);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+function relPath(filePath) {
+  return path.relative(docRoot, filePath).replace(/\\/g, '/');
+}
+
+const ignore = loadIgnoreRules();
+const urlToFiles = new Map();
+
+for (const { dir, exts } of scanRoots) {
+  for (const file of walk(dir, exts)) {
+    const content = fs.readFileSync(file, 'utf8');
+    const urls = extractExternalUrls(content);
+    const fileRel = relPath(file);
+    for (const url of urls) {
+      if (!urlToFiles.has(url)) urlToFiles.set(url, new Set());
+      urlToFiles.get(url).add(fileRel);
+    }
+  }
+}
+
+const allUrls = [...urlToFiles.keys()].sort();
+const skipped = [];
+const toCheck = [];
+
+for (const url of allUrls) {
+  if (shouldIgnore(url, ignore)) {
+    skipped.push({ url, files: [...urlToFiles.get(url)] });
+  } else {
+    toCheck.push(url);
+  }
+}
+
+console.log(`Checking ${toCheck.length} external URL(s) (${skipped.length} skipped)...\n`);
+
+const checkResults = await mapPool(toCheck, concurrency, async (url) => {
+  const result = await checkUrl(url);
+  process.stdout.write(result.ok ? '.' : 'x');
+  return { url, ...result, files: [...urlToFiles.get(url)] };
+});
+console.log('\n');
+
+const broken = checkResults.filter((r) => !r.ok);
+const ok = checkResults.filter((r) => r.ok);
+
+function mdEscape(s) {
+  return s.replace(/\|/g, '\\|');
+}
+
+const lines = [
+  '# External Link Audit Report',
+  '',
+  `Generated: ${new Date().toISOString()}`,
+  '',
+  '## Summary',
+  '',
+  '| Metric | Count |',
+  '|--------|------:|',
+  `| Unique external URLs found | ${allUrls.length} |`,
+  `| Checked | ${toCheck.length} |`,
+  `| Skipped (ignored) | ${skipped.length} |`,
+  `| OK | ${ok.length} |`,
+  `| **Broken** | **${broken.length}** |`,
+  '',
+];
+
+if (broken.length > 0) {
+  lines.push('## Broken links', '', '| URL | Status | Error | Referenced in |', '|-----|--------|-------|---------------|');
+  for (const row of broken.sort((a, b) => a.url.localeCompare(b.url))) {
+    const status = row.status ? String(row.status) : '—';
+    const err = row.error ? mdEscape(row.error) : '—';
+    const files = row.files.map((f) => `\`${f}\``).join(', ');
+    lines.push(`| ${mdEscape(row.url)} | ${status} | ${err} | ${files} |`);
+  }
+  lines.push('');
+}
+
+if (skipped.length > 0) {
+  lines.push('## Skipped URLs', '');
+  for (const { url, files } of skipped.sort((a, b) => a.url.localeCompare(b.url))) {
+    lines.push(`- \`${url}\` — ${files.map((f) => `\`${f}\``).join(', ')}`);
+  }
+  lines.push('');
+}
+
+lines.push('## How to fix', '');
+lines.push('- Update or remove broken URLs in the files listed above.');
+lines.push('- Add intentional placeholders to `scripts/external-link-ignore.json` only for localhost/demo URLs.');
+lines.push('- Re-run: `bun run check:external-links` from the `documentation/` directory.');
+lines.push('');
+
+fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+fs.writeFileSync(reportPath, lines.join('\n'));
+
+console.log(`Report written to ${reportRel}\n`);
+
+if (broken.length > 0) {
+  console.log('Broken external links:');
+  for (const row of broken) {
+    console.log(`  [${row.status || 'ERR'}] ${row.url}`);
+    for (const f of row.files) console.log(`         → ${f}`);
+  }
+  process.exit(1);
+}
+
+console.log('All checked external links OK.');
+process.exit(0);

--- a/documentation/scripts/external-link-ignore.json
+++ b/documentation/scripts/external-link-ignore.json
@@ -1,0 +1,19 @@
+{
+  "hostPatterns": [
+    "^localhost$",
+    "^127\\.0\\.0\\.1$",
+    "^example\\.com$",
+    "^www\\.example\\.com$",
+    "^stackoverflow\\.com$"
+  ],
+  "urlPatterns": [
+    "^https://example\\.com/",
+    "^http://localhost",
+    "^https://localhost",
+    "soroban-testnet\\.stellar\\.org",
+    "validationcloud\\.io/v1/"
+  ],
+  "urls": [
+    "https://github.com/your-repo"
+  ]
+}

--- a/documentation/scripts/link-registry.json
+++ b/documentation/scripts/link-registry.json
@@ -1,0 +1,289 @@
+{
+  "hubs": {
+    "home": "/docs/",
+    "getting-started": "/docs/getting-started/setup",
+    "concepts": "/docs/concepts/overview",
+    "patterns": "/docs/patterns/overview",
+    "security": "/docs/security/fundamentals",
+    "contributing": "/docs/contributing"
+  },
+  "pages": {
+    "index": {
+      "category": "home",
+      "minInternalLinks": 4,
+      "requiredLinks": [
+        "/docs/getting-started/setup",
+        "/docs/concepts/overview",
+        "/docs/patterns/overview"
+      ]
+    },
+    "getting-started/setup": {
+      "category": "getting-started",
+      "minInternalLinks": 3,
+      "requiredLinks": [
+        "/docs/getting-started/first-contract",
+        "/docs/concepts/overview"
+      ]
+    },
+    "getting-started/setup-linux": {
+      "category": "getting-started",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/getting-started/first-contract"]
+    },
+    "getting-started/setup-windows": {
+      "category": "getting-started",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/getting-started/first-contract"]
+    },
+    "getting-started/first-contract": {
+      "category": "getting-started",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/getting-started/building-and-compilation"]
+    },
+    "getting-started/building-and-compilation": {
+      "category": "getting-started",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/getting-started/local-testing-and-simulation"]
+    },
+    "getting-started/local-testing-and-simulation": {
+      "category": "getting-started",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/getting-started/deploy-testnet"]
+    },
+    "getting-started/deploy-testnet": {
+      "category": "getting-started",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/getting-started/deploy-mainnet"]
+    },
+    "getting-started/deploy-mainnet": {
+      "category": "getting-started",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/security/fundamentals"]
+    },
+    "getting-started/contract-interaction": {
+      "category": "getting-started",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/patterns/overview"]
+    },
+    "getting-started/debugging": {
+      "category": "getting-started",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/getting-started/testing-errors"]
+    },
+    "getting-started/testing-errors": {
+      "category": "getting-started",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/concepts/error-handling"]
+    },
+    "contributing": {
+      "category": "contributing",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/contributing/internal-linking"]
+    },
+    "contributing/add-tested-example": {
+      "category": "contributing",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/contributing"]
+    },
+    "contributing/image-optimization": {
+      "category": "contributing",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/contributing"]
+    },
+    "contributing/performance-impact": {
+      "category": "contributing",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/contributing"]
+    },
+    "contributing/internal-linking": {
+      "category": "contributing",
+      "minInternalLinks": 3,
+      "requiredLinks": [
+        "/docs/contributing",
+        "/docs/concepts/overview",
+        "/docs/patterns/overview"
+      ]
+    },
+    "concepts/introduction": {
+      "category": "concepts",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/concepts/overview"]
+    },
+    "concepts/overview": {
+      "category": "concepts",
+      "minInternalLinks": 4,
+      "requiredLinks": [
+        "/docs/concepts/storage",
+        "/docs/concepts/authorization",
+        "/docs/concepts/events"
+      ]
+    },
+    "concepts/best-practices": {
+      "category": "concepts",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/security/fundamentals"]
+    },
+    "concepts/storage": {
+      "category": "concepts",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/concepts/authorization"]
+    },
+    "concepts/authorization": {
+      "category": "concepts",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/security/fundamentals"]
+    },
+    "concepts/events": {
+      "category": "concepts",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/concepts/storage"]
+    },
+    "concepts/gas-and-resources": {
+      "category": "concepts",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/patterns/optimization-playbook"]
+    },
+    "concepts/error-handling": {
+      "category": "concepts",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/patterns/error-handling"]
+    },
+    "concepts/cross-contract-invocation": {
+      "category": "concepts",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/security/fundamentals"]
+    },
+    "patterns/overview": {
+      "category": "patterns",
+      "minInternalLinks": 4,
+      "requiredLinks": [
+        "/docs/patterns/hello-world",
+        "/docs/security/token-audit"
+      ]
+    },
+    "patterns/hello-world": {
+      "category": "patterns",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/concepts/storage"]
+    },
+    "patterns/custom-types": {
+      "category": "patterns",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/concepts/storage"]
+    },
+    "patterns/authorization": {
+      "category": "patterns",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/concepts/authorization"]
+    },
+    "patterns/optimization-playbook": {
+      "category": "patterns",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/concepts/gas-and-resources"]
+    },
+    "patterns/lifecycle-upgrades": {
+      "category": "patterns",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/security/fundamentals"]
+    },
+    "patterns/proposal-lifecycle": {
+      "category": "patterns",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/security/governance"]
+    },
+    "patterns/error-handling": {
+      "category": "patterns",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/concepts/error-handling"]
+    },
+    "patterns/error-recovery": {
+      "category": "patterns",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/concepts/error-handling"]
+    },
+    "security/fundamentals": {
+      "category": "security",
+      "minInternalLinks": 3,
+      "requiredLinks": [
+        "/docs/security/token-audit",
+        "/docs/concepts/authorization"
+      ]
+    },
+    "security/governance": {
+      "category": "security",
+      "minInternalLinks": 2,
+      "requiredLinks": [
+        "/docs/security/fundamentals",
+        "/docs/patterns/proposal-lifecycle"
+      ]
+    },
+    "security/token-audit": {
+      "category": "security",
+      "minInternalLinks": 3,
+      "requiredLinks": [
+        "/docs/security/fundamentals",
+        "/docs/patterns/overview"
+      ]
+    },
+    "design-system/buttons": {
+      "category": "design-system",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/design-system/typography"]
+    },
+    "design-system/typography": {
+      "category": "design-system",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/design-system/buttons"]
+    },
+    "design-system/badges-tags": {
+      "category": "design-system",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/design-system/typography"]
+    },
+    "design-system/empty-states": {
+      "category": "design-system",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/design-system/buttons"]
+    },
+    "design-system/alerts-callouts": {
+      "category": "design-system",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/components/alerts"]
+    },
+    "components/buttons": {
+      "category": "components",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/design-system/buttons"]
+    },
+    "components/testimonials": {
+      "category": "components",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/design-system/empty-states"]
+    },
+    "components/alerts": {
+      "category": "components",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/design-system/alerts-callouts"]
+    },
+    "components/callouts": {
+      "category": "components",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/design-system/alerts-callouts"]
+    },
+    "components/iconography": {
+      "category": "components",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/design-system/typography"]
+    },
+    "components/alert-callout-showcase": {
+      "category": "components",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/components/alerts"]
+    },
+    "responsive/breakpoints": {
+      "category": "responsive",
+      "minInternalLinks": 2,
+      "requiredLinks": ["/docs/design-system/typography"]
+    }
+  }
+}

--- a/documentation/sidebars.ts
+++ b/documentation/sidebars.ts
@@ -21,6 +21,7 @@ const sidebars: SidebarsConfig = {
         'getting-started/contract-interaction',
         'contributing',
         'contributing/add-tested-example',
+        'contributing/internal-linking',
       ],
     },
     {
@@ -55,6 +56,8 @@ const sidebars: SidebarsConfig = {
       label: 'Security',
       items: [
         'security/fundamentals',
+        'security/governance',
+        'security/token-audit',
       ],
     },
     {

--- a/documentation/src/components/UI/Testimonials/index.tsx
+++ b/documentation/src/components/UI/Testimonials/index.tsx
@@ -135,7 +135,7 @@ const defaultCommunityLinks: CommunityLink[] = [
   },
   {
     label: 'GitHub',
-    url: 'https://github.com/Soroban-Cookbook/Soroban-Cookbook-',
+    url: 'https://github.com/Soroban-Cookbook/Soroban_Cookbook_online',
     icon: <GithubIcon />,
     description: 'Contribute code, docs, and examples.',
   },

--- a/documentation/src/pages/404.tsx
+++ b/documentation/src/pages/404.tsx
@@ -17,7 +17,7 @@ const recoveryLinks = [
     description: 'Explore production-ready contract patterns',
   },
   {
-    href: 'https://github.com/Soroban-Cookbook/Soroban-Cookbook-',
+    href: 'https://github.com/Soroban-Cookbook/Soroban_Cookbook_online',
     icon: '⭐',
     label: 'GitHub',
     description: 'View source and contribute',

--- a/documentation/src/pages/markdown-page.md
+++ b/documentation/src/pages/markdown-page.md
@@ -2,6 +2,4 @@
 title: Markdown page example
 ---
 
-# Markdown page example
-
 You don't need React to write simple standalone pages.

--- a/documentation/src/theme/NotFound/index.tsx
+++ b/documentation/src/theme/NotFound/index.tsx
@@ -17,7 +17,7 @@ const recoveryLinks = [
     description: 'Explore production-ready contract patterns',
   },
   {
-    href: 'https://github.com/Soroban-Cookbook/Soroban-Cookbook-',
+    href: 'https://github.com/Soroban-Cookbook/Soroban_Cookbook_online',
     icon: '⭐',
     label: 'GitHub',
     description: 'View source and contribute',


### PR DESCRIPTION
Summary
This PR improves documentation SEO, navigation, and link health across the Soroban Cookbook site.

Heading hierarchy (H1–H6)
Removed duplicate H1s where frontmatter title: and markdown # both existed (33+ pages)
Standardized docs to use frontmatter title as the sole H1, with body content starting at ##
Added documentation/scripts/audit-heading-hierarchy.mjs and bun run audit:headings
Documented the convention in design-system/typography.mdx
Wired heading audit into CI

closes #171
closes #175
closes #177
closes #178