### PR TITLE
[354] Phase 7: Dependency Update Automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+# Dependabot configuration for Soroban Cookbook
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# The documentation site uses Bun (bun.lock) under documentation/.
+# Dependabot's npm ecosystem updates package.json and regenerates bun.lock
+# when a Bun lockfile is present in that directory.
+version: 2
+updates:
+  # Application / documentation dependencies (Bun + package.json)
+  - package-ecosystem: "npm"
+    directory: "/documentation"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore(deps)"
+    # Groups reduce PR noise for non-major updates within the same ecosystem area
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
+      eslint:
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint/*"
+      testing:
+        patterns:
+          - "vitest*"
+          - "@vitest/*"
+          - "@testing-library/*"
+          - "@playwright/*"
+          - "jsdom"
+
+  # GitHub Actions used by workflows under .github/workflows/
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
## Summary
- Added weekly Dependabot dependency update automation.
- Configured application dependencies (`npm` ecosystem for `/documentation`, including `bun.lock`).
- Configured GitHub Actions dependency updates.

Closes #354

## Testing
- [x] YAML structure validation (`version: 2`, npm + github-actions, weekly schedule, correct directories)
- [ ] `npm run lint` — N/A for config-only change (no application source changes)
- [ ] `npm run build` — N/A for config-only change

## Note
Dependabot scheduled PR creation cannot be verified until GitHub runs the Dependabot schedule after this configuration is merged. This change only adds the configuration that enables automatic dependency PRs.