### PR TITLE
[355] Phase 7: Performance Budgets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,9 @@ jobs:
       - name: Build documentation
         run: bun run build
 
+      - name: Enforce performance budgets
+        run: bun run check:bundle-budget
+
       - name: Verify build artifact
         run: |
           if [ ! -d build ]; then

--- a/documentation/bundle-budgets.json
+++ b/documentation/bundle-budgets.json
@@ -1,0 +1,39 @@
+{
+  "description": "CI bundle size budgets for the Docusaurus documentation build. Thresholds are based on measured production asset sizes (2026-07) with ~12% headroom for intentional growth. Update deliberately when a feature requires a larger budget.",
+  "measuredAt": "2026-07-27",
+  "notes": [
+    "Sizes are uncompressed on-disk bytes after `bun run build` (not gzip transfer size).",
+    "Total JS includes all code-split chunks; the main entry is checked separately as the critical-path budget.",
+    "The older `.performancebudget.json` values (300 KB JS / 50 KB CSS) are aspirational Lighthouse resource targets and are intentionally not used as hard CI gates here because they do not match current output."
+  ],
+  "budgets": [
+    {
+      "id": "main-js",
+      "description": "Main client JavaScript entry (critical path)",
+      "pattern": "build/assets/js/main.*.js",
+      "aggregate": false,
+      "maxBytes": 614400
+    },
+    {
+      "id": "main-css",
+      "description": "Primary stylesheet",
+      "pattern": "build/assets/css/styles.*.css",
+      "aggregate": false,
+      "maxBytes": 225280
+    },
+    {
+      "id": "total-js",
+      "description": "All JavaScript assets under build/",
+      "pattern": "build/**/*.js",
+      "aggregate": true,
+      "maxBytes": 2359296
+    },
+    {
+      "id": "total-css",
+      "description": "All CSS assets under build/",
+      "pattern": "build/**/*.css",
+      "aggregate": true,
+      "maxBytes": 225280
+    }
+  ]
+}

--- a/documentation/docs/contributing/performance-budgets.md
+++ b/documentation/docs/contributing/performance-budgets.md
@@ -1,0 +1,45 @@
+# Performance Budgets (CI)
+
+The documentation site enforces **on-disk bundle size budgets** in CI after
+`bun run build`. Builds fail when JavaScript or CSS assets exceed the
+configured thresholds.
+
+## Configuration
+
+| File | Role |
+|------|------|
+| `documentation/bundle-budgets.json` | Hard CI budgets (this issue) |
+| `documentation/.performancebudget.json` | Historical / Lighthouse-oriented targets (not the CI gate) |
+| `documentation/scripts/check-performance-budget.mjs` | Checker script |
+| `.github/workflows/ci.yml` | Runs the checker in the **Build Documentation** job |
+
+## Current budgets
+
+Measured from a production build on 2026-07-27, then given ~12% headroom:
+
+| Budget ID | What is measured | Limit |
+|-----------|------------------|-------|
+| `main-js` | `build/assets/js/main.*.js` | 600 KB (614,400 bytes) |
+| `main-css` | `build/assets/css/styles.*.css` | 220 KB (225,280 bytes) |
+| `total-js` | All `build/**/*.js` | ~2.25 MB (2,359,296 bytes) |
+| `total-css` | All `build/**/*.css` | 220 KB (225,280 bytes) |
+
+Sizes are **uncompressed** file sizes on disk (not gzip transfer size).
+
+## Local usage
+
+```bash
+cd documentation
+bun run build
+bun run check:bundle-budget
+```
+
+To confirm CI would fail on regression, temporarily lower a limit in
+`bundle-budgets.json` and re-run the check (do not commit the lowered value).
+
+## Updating budgets intentionally
+
+1. Run `bun run build` and note the checker output.
+2. Raise only the budget IDs that must grow, with a small margin.
+3. Explain the reason in the PR (new dependency, larger syntax highlighter, etc.).
+4. Prefer code-splitting / lazy-loading before raising `main-js` or `total-js`.

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -26,6 +26,7 @@
     "test": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "check:bundle-budget": "node scripts/check-performance-budget.mjs",
 
     "audit:headings": "node scripts/audit-heading-hierarchy.mjs",
     "audit:links": "node scripts/audit-internal-links.mjs",

--- a/documentation/scripts/check-performance-budget.mjs
+++ b/documentation/scripts/check-performance-budget.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Enforce documentation bundle size budgets after `bun run build`.
+ *
+ * Usage:
+ *   node scripts/check-performance-budget.mjs
+ *   node scripts/check-performance-budget.mjs --budgets bundle-budgets.json
+ *
+ * Exit codes:
+ *   0 — all budgets within limits
+ *   1 — one or more budgets exceeded, or configuration/build missing
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const args = process.argv.slice(2);
+const budgetsArgIndex = args.indexOf('--budgets');
+const budgetsPath = path.resolve(
+  root,
+  budgetsArgIndex >= 0 && args[budgetsArgIndex + 1]
+    ? args[budgetsArgIndex + 1]
+    : 'bundle-budgets.json',
+);
+
+function fail(message) {
+  console.error(`❌ ${message}`);
+  process.exit(1);
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  return `${(kb / 1024).toFixed(2)} MB`;
+}
+
+function globToRegExp(pattern) {
+  const escaped = pattern
+    .replace(/\\/g, '/')
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '::DOUBLE::')
+    .replace(/\*/g, '[^/]*')
+    .replace(/::DOUBLE::/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+function walkFiles(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(full, out);
+    } else {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function matchFiles(pattern) {
+  const buildRoot = path.join(root, 'build');
+  if (!fs.existsSync(buildRoot)) {
+    fail(`Build directory not found at ${buildRoot}. Run \`bun run build\` first.`);
+  }
+  const re = globToRegExp(pattern.replace(/\\/g, '/'));
+  return walkFiles(buildRoot)
+    .map((abs) => ({
+      abs,
+      rel: path.relative(root, abs).split(path.sep).join('/'),
+      size: fs.statSync(abs).size,
+    }))
+    .filter((f) => re.test(f.rel));
+}
+
+function checkBudget(budget) {
+  const files = matchFiles(budget.pattern);
+  if (files.length === 0) {
+    return {
+      id: budget.id,
+      ok: false,
+      detail: `No files matched pattern \`${budget.pattern}\``,
+    };
+  }
+
+  if (budget.aggregate) {
+    const total = files.reduce((sum, f) => sum + f.size, 0);
+    const ok = total <= budget.maxBytes;
+    return {
+      id: budget.id,
+      ok,
+      detail: `${budget.description}: ${formatBytes(total)} / ${formatBytes(budget.maxBytes)} across ${files.length} file(s)${ok ? '' : ' — EXCEEDED'}`,
+      total,
+    };
+  }
+
+  const largest = files.reduce((a, b) => (a.size >= b.size ? a : b));
+  const ok = files.every((f) => f.size <= budget.maxBytes);
+  return {
+    id: budget.id,
+    ok,
+    detail: `${budget.description}: largest ${largest.rel} is ${formatBytes(largest.size)} / ${formatBytes(budget.maxBytes)}${ok ? '' : ' — EXCEEDED'}`,
+    total: largest.size,
+  };
+}
+
+function main() {
+  if (!fs.existsSync(budgetsPath)) {
+    fail(`Budget config not found: ${budgetsPath}`);
+  }
+
+  const config = JSON.parse(fs.readFileSync(budgetsPath, 'utf8'));
+  if (!Array.isArray(config.budgets) || config.budgets.length === 0) {
+    fail('Budget config must include a non-empty `budgets` array.');
+  }
+
+  console.log('📦 Checking documentation performance budgets…');
+  console.log(`   Config: ${path.relative(root, budgetsPath)}`);
+
+  const results = config.budgets.map(checkBudget);
+  for (const result of results) {
+    console.log(`${result.ok ? '✅' : '❌'} [${result.id}] ${result.detail}`);
+  }
+
+  const failed = results.filter((r) => !r.ok);
+  if (failed.length > 0) {
+    console.error('');
+    console.error(
+      `${failed.length} budget(s) exceeded. If this growth is intentional, update documentation/bundle-budgets.json and document why in the PR.`,
+    );
+    process.exit(1);
+  }
+
+  console.log('✅ All performance budgets passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary
- Added CI performance budget enforcement.
- Added JavaScript/CSS bundle thresholds based on measured production output (~12% headroom).
- Configured CI to fail on budget regression.
- Documented budget thresholds and how to update them intentionally.

Closes #355

## Testing
- [x] `bun run check:bundle-budget` passes against current build
- [x] Controlled over-budget failure: lowering `main-js` to 1000 bytes exits non-zero (not committed)
- [x] CI workflow updated (budget step after `bun run build`)
- [ ] Full `bun run lint` locally skipped for unrelated Windows `autocrlf` CRLF noise; Linux CI remains source of truth

Made with [Cursor](https://cursor.com)