### PR TITLE
ci: add automated staging deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - staging
   workflow_dispatch:
 
 permissions:
@@ -46,6 +47,7 @@ jobs:
         env:
           # Sourced from GitHub Repository Secrets — never hardcode these values.
           # See DEPLOYMENT.md → Environment Variables for setup instructions.
+          SITE_URL: ${{ github.ref_name == 'main' && 'https://soroban-cookbook.dev' || 'https://staging.soroban-cookbook.dev' }}
           NEWSLETTER_ENDPOINT: ${{ secrets.NEWSLETTER_ENDPOINT }}
           DISCORD_INVITE_URL: ${{ secrets.DISCORD_INVITE_URL }}
           # Analytics stays disabled until these are set — see DEPLOYMENT.md → Analytics.
@@ -58,11 +60,15 @@ jobs:
           path: ./build
 
   deploy:
+    if: github.ref_name == 'main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Configure Pages
         uses: actions/configure-pages@v4
@@ -75,7 +81,49 @@ jobs:
         run: |
           echo "## ✅ Deployment Complete"
           echo ""
-          echo "**Environment**: GitHub Pages"
+          echo "**Environment**: Production (GitHub Pages)"
           echo "**URL**: ${{ steps.deployment.outputs.page_url }}"
           echo "**Commit**: ${{ github.sha }}"
           echo "**Branch**: ${{ github.ref_name }}"
+
+  deploy-staging:
+    if: github.ref_name == 'staging'
+    environment:
+      name: staging
+      url: https://staging.soroban-cookbook.dev
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-pages
+          path: ./build-artifact
+
+      - name: Extract Build Artifact
+        run: |
+          mkdir -p ./build
+          tar -xf ./build-artifact/artifact.tar -C ./build
+
+      - name: Deploy Staging to gh-pages-staging branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          publish_branch: gh-pages-staging
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Deployment Summary
+        run: |
+          echo "## ✅ Deployment Complete"
+          echo ""
+          echo "**Environment**: Staging"
+          echo "**Branch**: gh-pages-staging"
+          echo "**URL**: https://staging.soroban-cookbook.dev"
+          echo "**Commit**: ${{ github.sha }}"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -157,11 +157,32 @@ If the issue persists after revert, you can manually rollback the GitHub Pages d
 
 #### Staging Verification Before Production
 
-Test fixes on a staging environment first:
+This repository features an automated **staging deployment** pipeline configured within `.github/workflows/deploy.yml` that isolates staging builds to avoid any overwrites to the live production site.
 
-1. Deploy to a staging branch
-2. Verify the fix resolves the issue
-3. Merge staging branch to `main` for production deployment
+##### Split-Deployment Architecture
+
+Because GitHub Pages only supports a single active custom domain/deployment per repository, deploying staging to the same Pages target directly would overwrite your production environment. To solve this, our deployment pipeline uses a **split-deployment strategy**:
+
+1. **Production Deployment (`main` branch)**:
+   - Deploys automatically on merge to `main`.
+   - Uses the native `actions/deploy-pages` to deploy the static assets directly to GitHub Pages.
+   - Tied to the `github-pages` environment at `https://soroban-cookbook.dev`.
+
+2. **Staging Deployment (`staging` branch)**:
+   - Deploys automatically on push/merge to `staging`.
+   - Generates the build with `SITE_URL` dynamically set to `https://staging.soroban-cookbook.dev`.
+   - Pushes the compiled static directory to a dedicated **`gh-pages-staging`** branch using `peaceiris/actions-gh-pages`.
+   - This ensures staging remains safely isolated. Your custom domain provider (or external hosting platforms such as Vercel, Netlify, or Cloudflare Pages) can then be pointed to read from the `gh-pages-staging` branch to serve the staging site at `https://staging.soroban-cookbook.dev` without ever affecting your live site!
+
+##### Step-by-Step Staging and Production Release Process
+
+To test and release a new feature:
+1. Create a pull request targeting the `staging` branch to test integration.
+2. Push or merge changes to the `staging` branch.
+3. The CD pipeline will trigger and automatically push the new staging build to the `gh-pages-staging` branch.
+4. Verify that the staging site at `https://staging.soroban-cookbook.dev` behaves correctly.
+5. Once verified, create a pull request from `staging` to `main`.
+6. Merging to `main` will automatically build and deploy to the production environment (`github-pages`) at `https://soroban-cookbook.dev`.
 
 **Note:** This repository uses GitHub Pages for hosting, which tracks deployments. Each successful workflow run creates a deployment artifact that can be restored if needed.
 

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -126,13 +126,7 @@ const config: Config = {
         content: 'Soroban Cookbook',
       },
     },
-    {
-      tagName: 'meta',
-      attributes: {
-        property: 'og:image',
-        content: 'https://soroban-cookbook.dev/img/soroban-social-card.png',
-      },
-    },
+    // Open Graph image size tags (og:image, twitter:card, and twitter:image are automatically injected by Docusaurus from themeConfig.image)
     {
       tagName: 'meta',
       attributes: {
@@ -145,20 +139,6 @@ const config: Config = {
       attributes: {
         property: 'og:image:height',
         content: '630',
-      },
-    },
-    {
-      tagName: 'meta',
-      attributes: {
-        name: 'twitter:card',
-        content: 'summary_large_image',
-      },
-    },
-    {
-      tagName: 'meta',
-      attributes: {
-        name: 'twitter:image',
-        content: 'https://soroban-cookbook.dev/img/soroban-social-card.png',
       },
     },
   ],

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -11,8 +11,8 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://soroban-cookbook.dev',
-  baseUrl: '/',
+  url: process.env.SITE_URL || 'https://soroban-cookbook.dev',
+  baseUrl: process.env.BASE_URL || '/',
 
   organizationName: 'Soroban-Cookbook',
   projectName: 'Soroban_Cookbook_online',


### PR DESCRIPTION
Closes #161 

## Summary

Adds an automated staging deployment workflow while preserving the existing production deployment process.

## Changes

* Added staging deployment configuration
* Extended the GitHub Actions deployment workflow
* Reused existing deployment logic where appropriate
* Preserved production deployment behaviour
* Updated deployment configuration only where necessary