### PR TITLE
feat(docs): add CodeComparison side-by-side component (#317)

### DIFF
--- a/documentation/docs/patterns/lifecycle-upgrades.mdx
+++ b/documentation/docs/patterns/lifecycle-upgrades.mdx
@@ -27,6 +27,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { Callout } from '@site/src/components/Callout';
 import { Alert } from '@site/src/components/Alert';
+import { CodeComparison } from '@site/src/components/CodeComparison';
 
 ## Overview
 
@@ -71,8 +72,19 @@ A healthy protocol moves through distinct phases, each with specific entry and e
 
 Upgrades must be protected by strict access control. In Soroban, the `upgrade` function should typically require the authorization of an admin or a decentralized governance body.
 
-```rust illustrative
-#[contractimpl]
+<CodeComparison
+  beforeLabel="Insecure (before)"
+  afterLabel="Authorized (after)"
+  title="Adding access control to the upgrade function"
+  language="rust"
+  before={`#[contractimpl]
+impl MyContract {
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+        // Anyone can upgrade the contract — dangerous!
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+    }
+}`}
+  after={`#[contractimpl]
 impl MyContract {
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
@@ -80,8 +92,8 @@ impl MyContract {
 
         env.deployer().update_current_contract_wasm(new_wasm_hash);
     }
-}
-```
+}`}
+/>
 
 <Callout variant="tip" title="Governance Best Practice">
 For high-value protocols, avoid single-key admin accounts. Use a multi-signature account or a DAO with a mandatory timelock (e.g., 7 days) to allow users to exit if they disagree with a pending upgrade.

--- a/documentation/src/components/CodeComparison/CodeComparison.module.css
+++ b/documentation/src/components/CodeComparison/CodeComparison.module.css
@@ -1,0 +1,146 @@
+/**
+ * CodeComparison component styling
+ * Side-by-side diff of two code samples with added/removed highlighting
+ */
+
+.comparison {
+  margin: var(--space-6) 0;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--ifm-pre-background, var(--color-bg-secondary));
+}
+
+.caption {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--ifm-font-color-base);
+}
+
+.labels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color, var(--color-bg-secondary));
+}
+
+.label {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wide);
+}
+
+.labelBefore {
+  border-right: 1px solid var(--ifm-color-emphasis-300);
+}
+
+.diff {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.pane {
+  overflow-x: auto;
+  font-family: var(--font-family-mono, var(--ifm-font-family-monospace));
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+}
+
+.pane:first-child {
+  border-right: 1px solid var(--ifm-color-emphasis-300);
+}
+
+.line {
+  display: flex;
+  align-items: stretch;
+  min-height: var(--space-5);
+}
+
+.gutter {
+  flex-shrink: 0;
+  width: 3rem;
+  padding-right: var(--space-3);
+  text-align: right;
+  user-select: none;
+  color: var(--ifm-color-emphasis-500, var(--color-text-muted));
+  background: var(--ifm-background-surface-color, var(--color-bg-secondary));
+}
+
+.code {
+  white-space: pre;
+  padding-left: var(--space-3);
+  color: var(--ifm-code-color, var(--ifm-font-color-base));
+  font-family: inherit;
+  font-size: inherit;
+}
+
+/* Diff highlighting: removed lines (before) */
+.line--removed {
+  background-color: var(--color-error-50, rgba(239, 68, 68, 0.12));
+}
+
+.line--removed .code {
+  color: var(--color-error-800, #b91c1c);
+}
+
+/* Diff highlighting: added lines (after) */
+.line--added {
+  background-color: var(--color-success-50, rgba(34, 197, 94, 0.12));
+}
+
+.line--added .code {
+  color: var(--color-success-800, #15803d);
+}
+
+.lineEmpty .code {
+  color: transparent;
+}
+
+/* Dark mode diff highlighting */
+[data-theme='dark'] .line--removed {
+  background-color: rgba(239, 68, 68, 0.15);
+}
+
+[data-theme='dark'] .line--removed .code {
+  color: #fca5a5;
+}
+
+[data-theme='dark'] .line--added {
+  background-color: rgba(34, 197, 94, 0.12);
+}
+
+[data-theme='dark'] .line--added .code {
+  color: #86efac;
+}
+
+/* Stack panes vertically on narrow viewports */
+@media (max-width: 720px) {
+  .labels {
+    grid-template-columns: 1fr;
+  }
+
+  .labelBefore {
+    border-right: none;
+    border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  }
+
+  .diff {
+    grid-template-columns: 1fr;
+  }
+
+  .pane:first-child {
+    border-right: none;
+    border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  }
+}
+
+/* Respect reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .comparison {
+    transition: none;
+  }
+}

--- a/documentation/src/components/CodeComparison/CodeComparison.test.tsx
+++ b/documentation/src/components/CodeComparison/CodeComparison.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Tests for CodeComparison component
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CodeComparison from './CodeComparison';
+
+const before = `let x = 1;
+let y = 2;`;
+
+const after = `let x = 1;
+let y = 3;`;
+
+describe('CodeComparison Component', () => {
+  it('renders both panes with default labels', () => {
+    render(<CodeComparison before={before} after={after} />);
+    expect(screen.getByText('Before')).toBeInTheDocument();
+    expect(screen.getByText('After')).toBeInTheDocument();
+    expect(screen.getAllByText('let x = 1;')).toHaveLength(2);
+  });
+
+  it('renders custom labels', () => {
+    render(<CodeComparison before={before} after={after} beforeLabel="Old" afterLabel="New" />);
+    expect(screen.getByText('Old')).toBeInTheDocument();
+    expect(screen.getByText('New')).toBeInTheDocument();
+  });
+
+  it('renders an optional title as a caption', () => {
+    render(<CodeComparison before={before} after={after} title="Upgrade diff" />);
+    expect(screen.getByText('Upgrade diff')).toBeInTheDocument();
+  });
+
+  it('highlights changed lines in each pane', () => {
+    const { container } = render(<CodeComparison before={before} after={after} />);
+    // Both panes show 'let x = 1;' as unchanged and one differing line.
+    const panes = container.querySelectorAll('[class*="pane"]');
+    expect(panes).toHaveLength(2);
+    // The removed 'let y = 2;' appears once in the before pane.
+    expect(screen.getByText('let y = 2;')).toBeInTheDocument();
+    // The added 'let y = 3;' appears once in the after pane.
+    expect(screen.getByText('let y = 3;')).toBeInTheDocument();
+  });
+
+  it('renders line numbers by default', () => {
+    const { container } = render(<CodeComparison before={before} after={after} />);
+    const gutters = container.querySelectorAll('[class*="gutter"]');
+    expect(gutters.length).toBeGreaterThan(0);
+    expect(screen.getAllByText('1').length).toBeGreaterThan(0);
+  });
+
+  it('hides line numbers when showLineNumbers is false', () => {
+    const { container } = render(
+      <CodeComparison before={before} after={after} showLineNumbers={false} />,
+    );
+    expect(container.querySelectorAll('[class*="gutter"]')).toHaveLength(0);
+  });
+
+  it('applies a custom className', () => {
+    const { container } = render(
+      <CodeComparison before={before} after={after} className="my-compare" />,
+    );
+    expect(container.firstChild).toHaveClass('my-compare');
+  });
+
+  it('sets aria-labels on each pane', () => {
+    render(
+      <CodeComparison before={before} after={after} beforeLabel="Old code" afterLabel="New code" />,
+    );
+    const beforePane = screen.getByLabelText('Old code');
+    const afterPane = screen.getByLabelText('New code');
+    expect(beforePane).toBeInTheDocument();
+    expect(afterPane).toBeInTheDocument();
+  });
+
+  it('handles a fully empty before code block', () => {
+    const { container } = render(<CodeComparison before="" after={after} />);
+    expect(container.firstChild).toBeInTheDocument();
+    expect(screen.getByText('let x = 1;')).toBeInTheDocument();
+  });
+});

--- a/documentation/src/components/CodeComparison/CodeComparison.tsx
+++ b/documentation/src/components/CodeComparison/CodeComparison.tsx
@@ -1,0 +1,127 @@
+import React, { useMemo } from 'react';
+import clsx from 'clsx';
+import styles from './CodeComparison.module.css';
+import { diffLines, type DiffRow } from './diff';
+
+export interface CodeComparisonProps {
+  /** The "before" (old) code shown in the left pane */
+  before: string;
+  /** The "after" (new) code shown in the right pane */
+  after: string;
+  /** Label for the left pane */
+  beforeLabel?: string;
+  /** Label for the right pane */
+  afterLabel?: string;
+  /** Optional caption above the diff */
+  title?: string;
+  /** Programming language for the code panes */
+  language?: string;
+  /** Custom CSS class name */
+  className?: string;
+  /** Show line numbers in each pane (default true) */
+  showLineNumbers?: boolean;
+}
+
+const DEFAULT_BEFORE_LABEL = 'Before';
+const DEFAULT_AFTER_LABEL = 'After';
+
+/**
+ * CodeComparison Component
+ * ------------------------
+ * Renders two code samples side by side with line-level diff highlighting.
+ * Lines only present in the left pane are marked as removed; lines only in the
+ * right pane are marked as added. Stacked vertically on narrow viewports.
+ *
+ * @example
+ * ```tsx
+ * <CodeComparison
+ *   before={oldContract}
+ *   after={newContract}
+ *   beforeLabel="Before upgrade"
+ *   afterLabel="After upgrade"
+ *   language="rust"
+ * />
+ * ```
+ */
+export default function CodeComparison({
+  before,
+  after,
+  beforeLabel = DEFAULT_BEFORE_LABEL,
+  afterLabel = DEFAULT_AFTER_LABEL,
+  title,
+  language = 'rust',
+  className,
+  showLineNumbers = true,
+}: CodeComparisonProps) {
+  const rows: DiffRow[] = useMemo(() => diffLines(before, after), [before, after]);
+
+  return (
+    <figure className={clsx(styles.comparison, className)}>
+      {title && <figcaption className={styles.caption}>{title}</figcaption>}
+      <div className={styles.labels}>
+        <span className={clsx(styles.label, styles.labelBefore)}>{beforeLabel}</span>
+        <span className={clsx(styles.label, styles.labelAfter)}>{afterLabel}</span>
+      </div>
+      <div className={styles.diff}>
+        <div className={styles.pane} aria-label={beforeLabel}>
+          {rows.map((row, index) => {
+            const lineNumber = row.before !== null ? index + 1 : null;
+            return (
+              <DiffLine
+                key={index}
+                lineNumber={lineNumber}
+                row={row}
+                side="before"
+                showLineNumbers={showLineNumbers}
+                language={language}
+              />
+            );
+          })}
+        </div>
+        <div className={styles.pane} aria-label={afterLabel}>
+          {rows.map((row, index) => {
+            const lineNumber = row.after !== null ? index + 1 : null;
+            return (
+              <DiffLine
+                key={index}
+                lineNumber={lineNumber}
+                row={row}
+                side="after"
+                showLineNumbers={showLineNumbers}
+                language={language}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </figure>
+  );
+}
+
+interface DiffLineProps {
+  row: DiffRow;
+  side: 'before' | 'after';
+  lineNumber: number | null;
+  showLineNumbers: boolean;
+  language: string;
+}
+
+function DiffLine({ row, side, lineNumber, showLineNumbers, language }: DiffLineProps) {
+  const line = row[side];
+  const hasContent = line !== null;
+  const className = clsx(
+    styles.line,
+    !hasContent && styles.lineEmpty,
+    hasContent && styles[`line--${line.status}`],
+  );
+  const gutter = showLineNumbers ? (
+    <span className={styles.gutter}>{hasContent ? lineNumber : '\u00A0'}</span>
+  ) : null;
+
+  return (
+    <div className={className} data-language={language}>
+      {gutter}
+      <code className={styles.code}>{hasContent ? line.text || '\u00A0' : '\u00A0'}</code>
+    </div>
+  );
+}

--- a/documentation/src/components/CodeComparison/diff.test.ts
+++ b/documentation/src/components/CodeComparison/diff.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for CodeComparison diff utilities
+ */
+
+import { describe, it, expect } from 'vitest';
+import { diffLines, splitLines, type DiffRow } from './diff';
+
+describe('splitLines', () => {
+  it('splits code into lines', () => {
+    expect(splitLines('a\nb\nc')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('drops a single trailing newline', () => {
+    expect(splitLines('a\nb\n')).toEqual(['a', 'b']);
+  });
+
+  it('returns a single line for code without newlines', () => {
+    expect(splitLines('hello')).toEqual(['hello']);
+  });
+});
+
+describe('diffLines', () => {
+  it('returns unchanged rows for identical code', () => {
+    const rows = diffLines('a\nb', 'a\nb');
+    expect(rows).toEqual([
+      { before: { text: 'a', status: 'unchanged' }, after: { text: 'a', status: 'unchanged' } },
+      { before: { text: 'b', status: 'unchanged' }, after: { text: 'b', status: 'unchanged' } },
+    ]);
+  });
+
+  it('marks removed lines in before and added lines in after', () => {
+    const rows = diffLines('a\nb', 'a\nc');
+    const removed = rows.filter((r) => r.before?.status === 'removed');
+    const added = rows.filter((r) => r.after?.status === 'added');
+    expect(removed).toHaveLength(1);
+    expect(removed[0].before?.text).toBe('b');
+    expect(added).toHaveLength(1);
+    expect(added[0].after?.text).toBe('c');
+  });
+
+  it('aligns removed lines against an empty after slot', () => {
+    const rows = diffLines('a\nb', 'a');
+    const row = rows.find((r) => r.before?.text === 'b');
+    expect(row?.after).toBeNull();
+  });
+
+  it('aligns added lines against an empty before slot', () => {
+    const rows = diffLines('a', 'a\nb');
+    const row = rows.find((r) => r.after?.text === 'b');
+    expect(row?.before).toBeNull();
+  });
+
+  it('handles empty before code', () => {
+    const rows = diffLines('', 'a\nb');
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.before === null && r.after?.status === 'added')).toBe(true);
+  });
+
+  it('handles empty after code', () => {
+    const rows = diffLines('a\nb', '');
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.after === null && r.before?.status === 'removed')).toBe(true);
+  });
+
+  it('preserves total line count from both inputs', () => {
+    const before = 'x\n1\n2\n3\ny';
+    const after = 'x\na\nb\nc\ny';
+    const rows = diffLines(before, after);
+    const beforeCount = rows.filter((r) => r.before !== null).length;
+    const afterCount = rows.filter((r) => r.after !== null).length;
+    expect(beforeCount).toBe(5);
+    expect(afterCount).toBe(5);
+  });
+});
+
+const hasStatus = (rows: DiffRow[], side: 'before' | 'after', status: string): boolean =>
+  rows.some((r) => r[side]?.status === status);
+
+describe('diffLines output shape', () => {
+  it('only emits before/after line objects with expected fields', () => {
+    const rows = diffLines('a\nb', 'a\nc');
+    rows.forEach((row) => {
+      if (row.before) {
+        expect(typeof row.before.text).toBe('string');
+        expect(['unchanged', 'added', 'removed']).toContain(row.before.status);
+      }
+      if (row.after) {
+        expect(typeof row.after.text).toBe('string');
+        expect(['unchanged', 'added', 'removed']).toContain(row.after.status);
+      }
+    });
+    expect(hasStatus(rows, 'before', 'removed')).toBe(true);
+    expect(hasStatus(rows, 'after', 'added')).toBe(true);
+  });
+});

--- a/documentation/src/components/CodeComparison/diff.ts
+++ b/documentation/src/components/CodeComparison/diff.ts
@@ -1,0 +1,89 @@
+/**
+ * CodeComparison diff utilities
+ * Line-based LCS diff that aligns two code blocks for side-by-side rendering.
+ */
+
+export type DiffStatus = 'unchanged' | 'added' | 'removed';
+
+export interface DiffLine {
+  /** Line content without trailing newline */
+  text: string;
+  status: DiffStatus;
+}
+
+export interface DiffRow {
+  before: DiffLine | null;
+  after: DiffLine | null;
+}
+
+/**
+ * Split a code string into lines, dropping a single trailing newline.
+ */
+export function splitLines(code: string): string[] {
+  if (code === '') return [];
+  return code.replace(/\n$/, '').split('\n');
+}
+
+/**
+ * Compute the length of the longest common subsequence between two arrays.
+ * Used to keep diff memory bounded for typical doc code blocks.
+ */
+function lcsLengths(a: string[], b: string[]): number[][] {
+  const table: number[][] = Array.from({ length: a.length + 1 }, () => Array(b.length + 1).fill(0));
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      table[i][j] =
+        a[i] === b[j] ? table[i + 1][j + 1] + 1 : Math.max(table[i + 1][j], table[i][j + 1]);
+    }
+  }
+  return table;
+}
+
+/**
+ * Align two code blocks into side-by-side rows.
+ *
+ * Lines that exist only in `before` are marked as removed and aligned against
+ * an empty slot on the right; lines that exist only in `after` are marked as
+ * added and aligned against an empty slot on the left.
+ *
+ * @example
+ * diffLines('a\nb', 'a\nc') returns rows where `b` is removed and `c` is added.
+ */
+export function diffLines(before: string, after: string): DiffRow[] {
+  const beforeLines = splitLines(before);
+  const afterLines = splitLines(after);
+  const table = lcsLengths(beforeLines, afterLines);
+
+  const rows: DiffRow[] = [];
+  let i = 0;
+  let j = 0;
+
+  while (i < beforeLines.length && j < afterLines.length) {
+    if (beforeLines[i] === afterLines[j]) {
+      rows.push({
+        before: { text: beforeLines[i], status: 'unchanged' },
+        after: { text: afterLines[j], status: 'unchanged' },
+      });
+      i++;
+      j++;
+    } else if (table[i + 1][j] >= table[i][j + 1]) {
+      rows.push({ before: { text: beforeLines[i], status: 'removed' }, after: null });
+      i++;
+    } else {
+      rows.push({ before: null, after: { text: afterLines[j], status: 'added' } });
+      j++;
+    }
+  }
+
+  while (i < beforeLines.length) {
+    rows.push({ before: { text: beforeLines[i], status: 'removed' }, after: null });
+    i++;
+  }
+
+  while (j < afterLines.length) {
+    rows.push({ before: null, after: { text: afterLines[j], status: 'added' } });
+    j++;
+  }
+
+  return rows;
+}

--- a/documentation/src/components/CodeComparison/index.ts
+++ b/documentation/src/components/CodeComparison/index.ts
@@ -1,0 +1,9 @@
+/**
+ * CodeComparison Component Export
+ * Main export for the side-by-side code diff component
+ */
+
+export { default as CodeComparison } from './CodeComparison';
+export type { CodeComparisonProps } from './CodeComparison';
+export { diffLines, splitLines } from './diff';
+export type { DiffRow, DiffLine, DiffStatus } from './diff';

--- a/documentation/src/theme/MDXComponents.tsx
+++ b/documentation/src/theme/MDXComponents.tsx
@@ -12,6 +12,7 @@ import {
 import CodeSnippet from '@site/src/components/CodeSnippet';
 import Collapsible from '@site/src/components/Collapsible/Collapsible';
 import { Quiz } from '@site/src/components/Quiz';
+import { CodeComparison } from '@site/src/components/CodeComparison';
 
 export default {
   ...MDXComponents,
@@ -26,4 +27,5 @@ export default {
   CodeSnippet,
   Collapsible,
   Quiz,
+  CodeComparison,
 };


### PR DESCRIPTION
Closes #317

---

Adds a `CodeComparison` component that renders two code samples side by side with line-level diff highlighting, and wires it into the `lifecycle-upgrades` pattern.

## What changed

- **`documentation/src/components/CodeComparison/`** — new component:
  - `CodeComparison.tsx` — two-pane diff component (`before`/`after`, optional labels, caption, line numbers).
  - `diff.ts` — pure line-based LCS diff utilities (`diffLines`, `splitLines`).
  - `CodeComparison.module.css` — responsive layout (stacks on narrow viewports), added/removed line highlighting with light/dark mode.
  - `index.ts` — public exports.
  - `CodeComparison.test.tsx` + `diff.test.ts` — 20 unit tests.
- **`documentation/src/theme/MDXComponents.tsx`** — registers `CodeComparison` so it can be used in MDX.
- **`documentation/docs/patterns/lifecycle-upgrades.mdx`** — replaces the prose-only access-control example with a before/after `CodeComparison` (insecure vs authorized `upgrade`).

## Verification

- [x] `vitest` — 20/20 passing for the new component
- [x] `tsc --noEmit` — no errors
- [x] `prettier --check` — clean
- [x] `lifecycle-upgrades.mdx` compiles via `@mdx-js/mdx`

Note: `vitest.config.ts` on `main` currently has a syntax error (from merge #454) and ESLint 10 crashes with `eslint-plugin-react`; these pre-existing issues were worked around locally to verify this PR.

## Type of Change
- [x] 🎨 UI/UX Improvement